### PR TITLE
Visualise a reference energy system from a Tabular Data Package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ The aim of the package is to provide a community resource which
 centralises the commonly used pre- and post-processing steps
 around the use of OSeMOSYS.
 
+
 Installation
 ============
 
@@ -32,20 +33,31 @@ Install **otoole** using pip::
 
     pip install otoole
 
-Install a development version
-=============================
 
-To install the package in develop mode:
+Contributing
+============
+
+New ideas and bugs are found on the repository Issue Tracker.
+Please do contribute by discussing and developing these ideas further,
+or by developing the codebase.
+
+To contribute directly to the documentation of code development, you
+first need to install the package in *develop mode*:
 
     git clone http://github.com/OSeMOSYS/otoole
-    cd otoole                              #
-    git checkout <branch you wish to use>  # obtain the version of the source code you wish to use
-    python setup.py develop                # install the package in develop mode
+    cd otoole
+    git checkout <branch you wish to use>
+    python setup.py develop
+
+Now, all changes made in the codebase will automatically be reflected
+in the installed Python version accessible on the command line or from
+importing otoole modules into other Python packages.
 
 
+Usage
+=====
 
-Note
-====
+For detailed instructions of the use of the tool, run the command line
+help function::
 
-This project has been set up using PyScaffold 3.2.2. For details and usage
-information on PyScaffold see https://pyscaffold.org/.
+    otoole --help

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,17 @@ Install **otoole** using pip::
 
     pip install otoole
 
+Install a development version
+=============================
+
+To install the package in develop mode:
+
+    git clone http://github.com/OSeMOSYS/otoole
+    cd otoole                              #
+    git checkout <branch you wish to use>  # obtain the version of the source code you wish to use
+    python setup.py develop                # install the package in develop mode
+
+
 
 Note
 ====

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -23,6 +23,7 @@ import sys
 
 from otoole.preprocess import create_datafile, create_datapackage, generate_csv_from_excel
 from otoole.results.convert import convert_cplex_file
+from otoole.visualise import create_res
 
 
 def excel2csv(args):
@@ -40,6 +41,10 @@ def cplex2cbc(args):
 
 def datapackage2datafile(args):
     create_datafile(args.datapackage, args.datafile)
+
+
+def datapackage2res(args):
+    create_res(args.datapackage, args.resfile)
 
 
 def get_parser():
@@ -84,18 +89,28 @@ def get_parser():
                               help="Output only the results upto and including this year")
     cplex_parser.add_argument('output_format', choices=['csv', 'cbc'], default='cbc')
     cplex_parser.set_defaults(func=cplex2cbc)
+
+    # Parser for visualisation
+    viz_parser = subparsers.add_parser('viz', help='Visualise the model')
+    viz_subparsers = viz_parser.add_subparsers()
+
+    res_parser = viz_subparsers.add_parser('res', help='Generate a reference energy system')
+    res_parser.add_argument('datapackage', help='Path to model datapackage')
+    res_parser.add_argument('resfile', help='Path to reference energy system')
+    res_parser.set_defaults(func=datapackage2res)
+
     return parser
 
 
 def main():
 
-    logging.basicConfig(filename='myapp.log', level=logging.DEBUG, filemode='w')
+    logging.basicConfig(level=logging.INFO)
     logging.info('Started')
     parser = get_parser()
     args = parser.parse_args(sys.argv[1:])
 
     if args.v:
-        logging.basicConfig(filename='myapp.log', level=logging.DEBUG, filemode='a')
+        logging.basicConfig(level=logging.DEBUG)
 
     if 'func' in args:
         args.func(args)

--- a/src/otoole/visualise/__init__.py
+++ b/src/otoole/visualise/__init__.py
@@ -1,0 +1,3 @@
+from .res import create_res
+
+__all__ = ['create_res']

--- a/src/otoole/visualise/__init__.py
+++ b/src/otoole/visualise/__init__.py
@@ -1,3 +1,12 @@
+"""Visualise different aspects of an OSeMOSYS model and data
+
+Provides the following commands::
+
+    otoole viz res <path_to_datapackage.json> <path_to_res_image>
+
+``otoole viz res`` generates an image of the reference energy system in a datapackage
+
+"""
 from .res import create_res
 
 __all__ = ['create_res']

--- a/src/otoole/visualise/res.py
+++ b/src/otoole/visualise/res.py
@@ -60,7 +60,7 @@ def main(path_to_datapackage):
     nodes += extract_nodes(storage, node_type='storage', shape='triangle', color='lightblue')
     nodes += add_fuel(fuel)
     nodes += extract_nodes(emission, node_type='emission', color='grey')
-    nodes += [('AccumulatedAnnualDemand',
+    nodes += [('AnnualDemand',
                {'type': 'demand', 'fillcolor': 'green',
                 'name': 'AccumulatedAnnualDemand',
                 'style': 'filled'}
@@ -72,7 +72,8 @@ def main(path_to_datapackage):
     emission_activity = package.get_resource('EmissionActivityRatio').read(keyed=True)
     tech2storage = package.get_resource('TechnologyToStorage').read(keyed=True)
     techfromstorage = package.get_resource('TechnologyFromStorage').read(keyed=True)
-    demand = package.get_resource('AccumulatedAnnualDemand').read(keyed=True)
+    acc_demand = package.get_resource('AccumulatedAnnualDemand').read(keyed=True)
+    spec_demand = package.get_resource('SpecifiedAnnualDemand').read(keyed=True)
 
     edges = extract_edges(input_activity, 'FUEL', 'TECHNOLOGY', 'input_ratio', from_edge=False)
 
@@ -84,9 +85,12 @@ def main(path_to_datapackage):
 
     edges += extract_edges(techfromstorage, 'STORAGE', 'TECHNOLOGY', 'ouput_ratio')
 
-    edges += [(x['FUEL'], 'AccumulatedAnnualDemand',
-              {'Demand': float(x['VALUE'])})
-              for x in demand]
+    edges += [(x['FUEL'], 'AnnualDemand',
+              {'Demand': float(x['VALUE']), 'label': x['FUEL']})
+              for x in acc_demand]
+    edges += [(x['FUEL'], 'AnnualDemand',
+              {'Demand': float(x['VALUE']), 'label': x['FUEL']})
+              for x in spec_demand]
 
     graph = build_graph(nodes, edges)
     draw_graph(graph)

--- a/src/otoole/visualise/res.py
+++ b/src/otoole/visualise/res.py
@@ -7,19 +7,28 @@ from typing import Dict, List, Tuple
 import networkx as nx
 from datapackage import Package
 
+logger = logging.getLogger(__name__)
 
-def load_datapackage(path_to_datapackage: str):
+
+def load_datapackage(path_to_datapackage: str) -> Package:
 
     package = Package(path_to_datapackage)
 
     return package
 
 
-def main(path_to_datapackage):
+def create_res(path_to_datapackage: str, path_to_resfile: str):
+    """Create a reference energy system diagram from a Tabular Data Package
 
+    Arguments
+    ---------
+    path_to_datapackage : str
+        The path to the ``datapackage.json``
+    path_to_resfile : str
+        The path to the PNG file to be created
+    """
+    logger.debug(path_to_resfile, path_to_resfile)
     package = load_datapackage(path_to_datapackage)
-
-    # region = package.get_resource('REGION').read()
 
     technologies = package.get_resource('TECHNOLOGY').read()
     storage = package.get_resource('STORAGE').read()
@@ -36,22 +45,52 @@ def main(path_to_datapackage):
 
         return nodes
 
-    def add_fuel(package_rows: List[List]) -> List:
+    def add_fuel(package_rows: List[List]) -> List[Tuple[str, Dict]]:
+        """Add fuel nodes
+
+        Arguments
+        ---------
+        package_rows : list of dict
+
+        Returns
+        -------
+        list of tuple
+            A list of node names along with a dict of node attributes
+        """
         nodes = [(x[0],
                  {'type': 'fuel', 'style': 'filled', 'shape': 'circle', 'height': 0.1, 'width': 0.1, 'label': ""})
                  for x in package_rows]
         return nodes
 
-    def extract_edges(package_rows: List[Dict], from_column, to_column, value_attribute_name, from_edge: bool = True):
-        """[]
+    def extract_edges(package_rows: List[Dict], from_column: str,
+                      to_column: str, parameter_name: str,
+                      directed: bool = True) -> List[Tuple[str, str, Dict]]:
+        """Add edges from a Tabular Data Table
+
+        Arguments
+        ---------
+        package_rows : list of dict
+        from_column : str
+            The name of the column to use as source of the edge
+        to_column: str
+            The name of the column to use as a destination of the edge
+        parameter_name: str
+            The name of the parameter
+        directed: bool, default=True
+            Specifies whether the edge should have an arrow or not
+
+        Returns
+        -------
+        list of tuple
+            A list of edges with from/to nodes names and edge attributes
         """
-        if from_edge:
+        if directed:
             edges = [(x[from_column], x[to_column],
-                     {value_attribute_name: float(x['VALUE']), 'dir': 'none'})
+                     {parameter_name: float(x['VALUE']), 'dir': 'none'})
                      for x in package_rows]
         else:
             edges = [(x[from_column], x[to_column],
-                     {value_attribute_name: float(x['VALUE']), 'label': x[from_column]})
+                     {parameter_name: float(x['VALUE']), 'xlabel': x[from_column]})
                      for x in package_rows]
 
         return edges
@@ -75,7 +114,7 @@ def main(path_to_datapackage):
     acc_demand = package.get_resource('AccumulatedAnnualDemand').read(keyed=True)
     spec_demand = package.get_resource('SpecifiedAnnualDemand').read(keyed=True)
 
-    edges = extract_edges(input_activity, 'FUEL', 'TECHNOLOGY', 'input_ratio', from_edge=False)
+    edges = extract_edges(input_activity, 'FUEL', 'TECHNOLOGY', 'input_ratio', directed=False)
 
     edges += extract_edges(output_activity, 'TECHNOLOGY', 'FUEL', 'output_ratio')
 
@@ -86,17 +125,27 @@ def main(path_to_datapackage):
     edges += extract_edges(techfromstorage, 'STORAGE', 'TECHNOLOGY', 'ouput_ratio')
 
     edges += [(x['FUEL'], 'AnnualDemand',
-              {'Demand': float(x['VALUE']), 'label': x['FUEL']})
+              {'Demand': float(x['VALUE']), 'xlabel': x['FUEL']})
               for x in acc_demand]
     edges += [(x['FUEL'], 'AnnualDemand',
-              {'Demand': float(x['VALUE']), 'label': x['FUEL']})
+              {'Demand': float(x['VALUE']), 'xlabel': x['FUEL']})
               for x in spec_demand]
 
     graph = build_graph(nodes, edges)
-    draw_graph(graph)
+    draw_graph(graph, path_to_resfile)
 
 
-def draw_graph(graph):
+def draw_graph(graph, path_to_resfile):
+    """Layout the graph and write it to disk
+
+    Uses pygraphviz to set some graph attributes, layout the graph
+    and write it to disk
+
+    Arguments
+    ---------
+    path_to_resfile : str
+        The file path of the PNG image file that will be created
+    """
 
     pygraph = nx.nx_agraph.to_agraph(graph)
     pygraph.graph_attr['rankdir'] = 'LR'
@@ -104,10 +153,22 @@ def draw_graph(graph):
     pygraph.graph_attr['concentrate'] = 'true'
 
     pygraph.layout(prog='dot')
-    pygraph.draw('res.png')
+    pygraph.draw(path_to_resfile)
 
 
 def build_graph(nodes: List[Tuple], edges: List[Tuple[str, str, Dict]]):
+    """Builds the graph using networkx
+
+    Arguments
+    ---------
+    nodes : list
+    edges : list
+
+    Returns
+    -------
+    networkx.DiGraph
+        A directed graph representing the reference energy system
+    """
     graph = nx.DiGraph()
     graph.add_nodes_from(nodes)
     graph.add_edges_from(edges)
@@ -118,4 +179,5 @@ if __name__ == '__main__':
 
     logging.basicConfig(level=logging.DEBUG)
     path_to_datapackage = sys.argv[1]
-    main(path_to_datapackage)
+    path_to_resfile = sys.argv[2]
+    create_res(path_to_datapackage, path_to_resfile)

--- a/src/otoole/visualise/res.py
+++ b/src/otoole/visualise/res.py
@@ -100,6 +100,8 @@ def draw_graph(graph):
 
     pygraph = nx.nx_agraph.to_agraph(graph)
     pygraph.graph_attr['rankdir'] = 'LR'
+    pygraph.graph_attr['splines'] = 'ortho'
+    pygraph.graph_attr['concentrate'] = 'true'
 
     pygraph.layout(prog='dot')
     pygraph.draw('res.png')

--- a/src/otoole/visualise/res.py
+++ b/src/otoole/visualise/res.py
@@ -1,0 +1,78 @@
+"""Visualise the reference energy system
+"""
+import logging
+import sys
+from typing import Dict, List, Tuple
+
+import matplotlib.pyplot as plt
+import networkx as nx
+from datapackage import Package
+
+
+def load_datapackage(path_to_datapackage: str):
+
+    package = Package(path_to_datapackage)
+
+    return package
+
+
+def main(path_to_datapackage):
+
+    package = load_datapackage(path_to_datapackage)
+
+    # region = package.get_resource('REGION').read()
+
+    technologies = package.get_resource('TECHNOLOGY').read()
+    storage = package.get_resource('STORAGE').read()
+    fuel = package.get_resource('FUEL').read()
+    emission = package.get_resource('EMISSION').read()
+
+    def extract_nodes(package_rows: List[List], node_type='technology', color='red', shape='circle') -> List:
+        nodes = [(x[0], {'type': node_type, 'name': x,
+                         'fillcolor': color, 'shape': shape,
+                         'style': 'filled'})
+                 for x in package_rows]
+
+        return nodes
+
+    nodes = extract_nodes(technologies, shape='square', color='yellow')
+    nodes += extract_nodes(storage, node_type='storage', shape='triangle', color='blue')
+    nodes += extract_nodes(fuel, node_type='fuel', color='white')
+    nodes += extract_nodes(emission, node_type='emission', color='grey')
+
+    input_activity = package.get_resource('InputActivityRatio').read(keyed=True)
+    output_activity = package.get_resource('OutputActivityRatio').read(keyed=True)
+    emission_activity = package.get_resource('EmissionActivityRatio').read(keyed=True)
+
+    edges = [(x['FUEL'], x['TECHNOLOGY'], {'input_ratio': float(x['VALUE'])}) for x in input_activity]
+
+    edges += [(x['TECHNOLOGY'], x['FUEL'], {'output_ratio': float(x['VALUE'])}) for x in output_activity]
+
+    edges += [(x['TECHNOLOGY'], x['EMISSION'], {'emission_ratio': float(x['VALUE'])}) for x in emission_activity]
+
+    graph = build_graph(nodes, edges)
+    draw_graph(graph)
+
+
+def draw_graph(graph):
+
+    pos = nx.nx_agraph.graphviz_layout(graph, prog='neato')
+
+    nx.nx_agraph.write_dot(graph, 'file.dot')
+    nx.draw_networkx(graph, pos=pos)
+    # write_dot(graph, 'file.dot')
+    plt.savefig("res.png")
+
+
+def build_graph(nodes: List[Tuple], edges: List[Tuple[str, str, Dict]]):
+    graph = nx.DiGraph()
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
+    return graph
+
+
+if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.DEBUG)
+    path_to_datapackage = sys.argv[1]
+    main(path_to_datapackage)


### PR DESCRIPTION
- Visualises a reference energy system using networkx, graphviz and dot.
- Very useful for debugging purposes e.g. note that the simplicity model shown below has no CO2 emission for Diesel imports, and several orphaned fuels, emissions and technologies.

![image](https://user-images.githubusercontent.com/3727919/66738919-e0b13080-ee6f-11e9-85e0-cb3420918f0b.png)

To do:

- [ ] Add to the command-line-interface
- [ ] Add requirements to the package install script
- [ ] Write some tests