### PR TITLE
Convert an OSeMOSYS datafile into a Tabular Data Package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ install_requires =
     importlib_resources; python_version<'3.7'
     datapackage
     pandas
+    pulp
+    flatten_dict
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
     xlrd
     pyyaml
+    pygraphviz
     importlib_resources; python_version<'3.7'
     datapackage
     pandas

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -21,7 +21,7 @@ import argparse
 import logging
 import sys
 
-from otoole.preprocess import create_datafile, create_datapackage, generate_csv_from_excel
+from otoole.preprocess import convert_file_to_package, create_datafile, create_datapackage, generate_csv_from_excel
 from otoole.results.convert import convert_cplex_file
 
 
@@ -42,10 +42,18 @@ def datapackage2datafile(args):
     create_datafile(args.datapackage, args.datafile)
 
 
+def conversion_matrix(args):
+    if (args.convert_from == 'datafile') and (args.convert_to == 'datapackage'):
+        convert_file_to_package(args.from_file, args.to_file)
+    else:
+        msg = "Conversion from {} to {} is not yet implemented".format(args.convert_from, args.convert_to)
+        raise NotImplementedError(msg)
+
+
 def get_parser():
     parser = argparse.ArgumentParser(description="otoole: Python toolkit of OSeMOSYS users")
 
-    parser.add_argument('--verbose', '-v', help='Enable debug mode', action='count')
+    parser.add_argument('--verbose', '-v', help='Enable debug mode', action='count', default=0)
 
     subparsers = parser.add_subparsers()
 
@@ -69,6 +77,14 @@ def get_parser():
     datafile_parser.add_argument('datapackage', help='Path to destination for datapackage')
     datafile_parser.add_argument('datafile', help='Path to datafile')
     datafile_parser.set_defaults(func=datapackage2datafile)
+
+    # Parser for conversion
+    convert_parser = subparsers.add_parser('convert', help='Convert from one input format to another')
+    convert_parser.add_argument('--convert_from', '-f', help='Input data format to convert from')
+    convert_parser.add_argument('--convert_to', '-t', help='Input data format to convert to')
+    convert_parser.add_argument('--from_file', help="Path to file to convert from")
+    convert_parser.add_argument('--to_file', help='Path to file to convert to')
+    convert_parser.set_defaults(func=conversion_matrix)
 
     # Parser for the CPLEX related commands
     cplex_parser = subparsers.add_parser('cplex',

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -45,7 +45,7 @@ def datapackage2datafile(args):
 def get_parser():
     parser = argparse.ArgumentParser(description="otoole: Python toolkit of OSeMOSYS users")
 
-    parser.add_argument('-v', help='Enable debug mode', action='store_true')
+    parser.add_argument('--verbose', '-v', help='Enable debug mode', action='count')
 
     subparsers = parser.add_subparsers()
 
@@ -89,13 +89,14 @@ def get_parser():
 
 def main():
 
-    logging.basicConfig(filename='myapp.log', level=logging.DEBUG, filemode='w')
     logging.info('Started')
     parser = get_parser()
     args = parser.parse_args(sys.argv[1:])
 
-    if args.v:
-        logging.basicConfig(filename='myapp.log', level=logging.DEBUG, filemode='a')
+    if args.verbose >= 1 and args.verbose < 2:
+        logging.basicConfig(level=logging.INFO)
+    if args.verbose > 2:
+        logging.basicConfig(level=logging.DEBUG)
 
     if 'func' in args:
         args.func(args)

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -3,24 +3,28 @@
 Example
 -------
 >>> otoole --help
-usage: otoole [-h] [-v] {prep,cplex} ...
+usage: otoole [-h] [--verbose] [--version] {prep,convert,cplex,viz} ...
 
 otoole: Python toolkit of OSeMOSYS users
 
 positional arguments:
-  {prep,cplex}
-    prep        Prepare an OSeMOSYS datafile
-    cplex       Process a CPLEX solution file
+  {prep,convert,cplex,viz}
+    prep                Prepare an OSeMOSYS datafile
+    convert             Convert from one input format to another
+    cplex               Process a CPLEX solution file
+    viz                 Visualise the model
 
 optional arguments:
-  -h, --help    show this help message and exit
-  -v            Enable debug mode
+  -h, --help            show this help message and exit
+  --verbose, -v         Enable debug mode
+  --version, -V         The version of otoole
 
 """
 import argparse
 import logging
 import sys
 
+from otoole import __version__
 from otoole.preprocess import convert_file_to_package, create_datafile, create_datapackage, generate_csv_from_excel
 from otoole.results.convert import convert_cplex_file
 from otoole.visualise import create_res
@@ -59,6 +63,8 @@ def get_parser():
     parser = argparse.ArgumentParser(description="otoole: Python toolkit of OSeMOSYS users")
 
     parser.add_argument('--verbose', '-v', help='Enable debug mode', action='count', default=0)
+    parser.add_argument('--version', '-V', action='version', version=__version__,
+                        help='The version of otoole')
 
     subparsers = parser.add_subparsers()
 

--- a/src/otoole/preprocess/__init__.py
+++ b/src/otoole/preprocess/__init__.py
@@ -1,5 +1,6 @@
 from .excel_to_osemosys import generate_csv_from_excel
 from .create_datapackage import main as create_datapackage
 from .narrow_to_datafile import main as create_datafile
+from .datafile_to_datapackage import convert_file_to_package
 
-__all__ = ['generate_csv_from_excel', 'create_datapackage', 'create_datafile']
+__all__ = ['generate_csv_from_excel', 'create_datapackage', 'create_datafile', 'convert_file_to_package']

--- a/src/otoole/preprocess/__init__.py
+++ b/src/otoole/preprocess/__init__.py
@@ -3,4 +3,5 @@ from .create_datapackage import main as create_datapackage
 from .narrow_to_datafile import main as create_datafile
 from .datafile_to_datapackage import convert_file_to_package
 
-__all__ = ['generate_csv_from_excel', 'create_datapackage', 'create_datafile', 'convert_file_to_package']
+__all__ = ['generate_csv_from_excel', 'create_datapackage', 'create_datafile', 'convert_file_to_package',
+           'create_datapackage_from_datafile']

--- a/src/otoole/preprocess/datafile_to_datapackage.py
+++ b/src/otoole/preprocess/datafile_to_datapackage.py
@@ -1,0 +1,58 @@
+"""Converts an OSeMOSYS datafile to a Tabular Data Package
+
+"""
+import logging
+import sys
+
+from pulp import Amply
+
+from otoole.preprocess.excel_to_osemosys import read_config
+
+logger = logging.getLogger(__name__)
+
+
+def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
+    """Converts an OSeMOSYS datafile to a Tabular Data Package
+
+    Arguments
+    ---------
+    path_to_datafile: str
+    path_to_datapackage: str
+
+    """
+    parameter_definitions = load_parameter_definitions()
+    datafile_parser = Amply(parameter_definitions)
+    logger.debug(datafile_parser)
+
+    with open(path_to_datafile, 'r') as datafile:
+        datafile_parser.load_file(datafile)
+
+    with open(path_to_datapackage, 'w') as datapackage:
+        for symbol in datafile_parser.symbols:
+            datapackage.write(datafile_parser[symbol])
+
+
+def load_parameter_definitions():
+    """Load the set and parameter dimensions into datafile parser
+    """
+    config = read_config()
+
+    elements = ""
+
+    for name, attributes in config.items():
+        if attributes['type'] == 'param':
+            elements += 'param {} {};\n'.format(name, "{" + ",".join(attributes['indices']) + "}")
+        elif attributes['type'] == 'set':
+            elements += 'set {};\n'.format(name)
+
+    logger.debug(elements)
+    return elements
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    path_to_datafile = sys.argv[1]
+    path_to_datapackage = sys.argv[2]
+
+    convert_file_to_package(path_to_datafile, path_to_datapackage)

--- a/src/otoole/preprocess/datafile_to_datapackage.py
+++ b/src/otoole/preprocess/datafile_to_datapackage.py
@@ -11,10 +11,9 @@ from flatten_dict import flatten
 from pulp import Amply
 
 from otoole.preprocess.excel_to_osemosys import read_config
-from otoole.preprocess.longify_data import check_datatypes, check_set_datatype
+from otoole.preprocess.longify_data import check_datatypes, check_set_datatype, write_out_dataframe
 
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.DEBUG)
 
 
 def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
@@ -33,12 +32,16 @@ def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
     if not os.path.exists(path_to_datapackage):
         os.mkdir(path_to_datapackage)
     for name, df in dict_of_dataframes.items():
-        filepath = os.path.join(path_to_datapackage, name + '.csv')
-        df.to_csv(filepath)
+        write_out_dataframe(path_to_datapackage, name, df)
 
 
-def read_in_datafile(path_to_datafile: str, config: Dict):
-    """
+def read_in_datafile(path_to_datafile: str, config: Dict) -> Amply:
+    """Read in a datafile using the Amply parsing class
+
+    Arguments
+    ---------
+    path_to_datafile: str
+    config: Dict
     """
     parameter_definitions = load_parameter_definitions(config)
     datafile_parser = Amply(parameter_definitions)
@@ -50,7 +53,18 @@ def read_in_datafile(path_to_datafile: str, config: Dict):
     return datafile_parser
 
 
-def convert_amply_to_dataframe(datafile_parser, config) -> Dict:
+def convert_amply_to_dataframe(datafile_parser, config) -> Dict[str, pd.DataFrame]:
+    """Converts an amply parser to a dict of pandas dataframes
+
+    Arguments
+    ---------
+    datafile_parser : Amply
+    config : Dict
+
+    Returns
+    -------
+    dict of pandas.DataFrame
+    """
 
     dict_of_dataframes = {}
 
@@ -82,7 +96,13 @@ def convert_amply_to_dataframe(datafile_parser, config) -> Dict:
     return dict_of_dataframes
 
 
-def convert_amply_data_to_list(amply_data: Dict) -> List:
+def convert_amply_data_to_list(amply_data: Dict) -> List[List]:
+    """Flattens a dictionary into a list of lists
+
+    Arguments
+    ---------
+    amply_data: dict
+    """
 
     data = []
 
@@ -93,15 +113,12 @@ def convert_amply_data_to_list(amply_data: Dict) -> List:
     return data
 
 
-def write_file(path_to_datapackage, datafile_parser):
-
-    with open(path_to_datapackage, 'w') as datapackage:
-        for symbol in datafile_parser.symbols:
-            datapackage.write(datafile_parser[symbol].data)
-
-
-def load_parameter_definitions(config):
+def load_parameter_definitions(config: dict) -> str:
     """Load the set and parameter dimensions into datafile parser
+
+    Returns
+    -------
+    str
     """
     elements = ""
 

--- a/src/otoole/preprocess/datafile_to_datapackage.py
+++ b/src/otoole/preprocess/datafile_to_datapackage.py
@@ -2,13 +2,19 @@
 
 """
 import logging
+import os
 import sys
+from typing import Dict, List
 
+import pandas as pd
+from flatten_dict import flatten
 from pulp import Amply
 
 from otoole.preprocess.excel_to_osemosys import read_config
+from otoole.preprocess.longify_data import check_datatypes, check_set_datatype
 
 logger = logging.getLogger(__name__)
+# logging.basicConfig(level=logging.DEBUG)
 
 
 def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
@@ -18,25 +24,85 @@ def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
     ---------
     path_to_datafile: str
     path_to_datapackage: str
+        Path to the folder in which to write the new Tabular Data Package
 
     """
-    parameter_definitions = load_parameter_definitions()
+    config = read_config()
+    amply_datafile = read_in_datafile(path_to_datafile, config)
+    dict_of_dataframes = convert_amply_to_dataframe(amply_datafile, config)
+    if not os.path.exists(path_to_datapackage):
+        os.mkdir(path_to_datapackage)
+    for name, df in dict_of_dataframes.items():
+        filepath = os.path.join(path_to_datapackage, name + '.csv')
+        df.to_csv(filepath)
+
+
+def read_in_datafile(path_to_datafile: str, config: Dict):
+    """
+    """
+    parameter_definitions = load_parameter_definitions(config)
     datafile_parser = Amply(parameter_definitions)
     logger.debug(datafile_parser)
 
     with open(path_to_datafile, 'r') as datafile:
         datafile_parser.load_file(datafile)
 
+    return datafile_parser
+
+
+def convert_amply_to_dataframe(datafile_parser, config) -> Dict:
+
+    dict_of_dataframes = {}
+
+    for name in datafile_parser.symbols.keys():
+        logger.debug("Extracting data for %s", name)
+        if config[name]['type'] == 'param':
+            indices = config[name]['indices']
+            indices_dtypes = [config[index]['dtype'] for index in indices]
+            indices.append('VALUE')
+            indices_dtypes.append('float')
+
+            raw_data = datafile_parser[name].data
+            data = convert_amply_data_to_list(raw_data)
+            df = pd.DataFrame(data=data, columns=indices)
+            try:
+                dict_of_dataframes[name] = check_datatypes(df, config, name)
+            except ValueError as ex:
+                msg = "Validation error when checking datatype of {}: {}".format(name, str(ex))
+                raise ValueError(msg)
+        elif config[name]['type'] == 'set':
+            data = datafile_parser[name].data
+            logger.debug(data)
+
+            indices = ['VALUE']
+            df = pd.DataFrame(data=data, columns=indices, dtype=config[name]['dtype'])
+            dict_of_dataframes[name] = check_set_datatype(df, config, name)
+        logger.debug("\n%s\n", dict_of_dataframes[name])
+
+    return dict_of_dataframes
+
+
+def convert_amply_data_to_list(amply_data: Dict) -> List:
+
+    data = []
+
+    raw_data = flatten(amply_data)
+    for key, value in raw_data.items():
+        data.append(list(key) + [value])
+
+    return data
+
+
+def write_file(path_to_datapackage, datafile_parser):
+
     with open(path_to_datapackage, 'w') as datapackage:
         for symbol in datafile_parser.symbols:
-            datapackage.write(datafile_parser[symbol])
+            datapackage.write(datafile_parser[symbol].data)
 
 
-def load_parameter_definitions():
+def load_parameter_definitions(config):
     """Load the set and parameter dimensions into datafile parser
     """
-    config = read_config()
-
     elements = ""
 
     for name, attributes in config.items():

--- a/src/otoole/preprocess/datafile_to_datapackage.py
+++ b/src/otoole/preprocess/datafile_to_datapackage.py
@@ -10,7 +10,7 @@ import pandas as pd
 from flatten_dict import flatten
 from pulp import Amply
 
-from otoole.preprocess.excel_to_osemosys import read_config
+from otoole.preprocess.excel_to_osemosys import read_config, read_datapackage
 from otoole.preprocess.longify_data import check_datatypes, check_set_datatype, write_out_dataframe
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,10 @@ def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
         os.mkdir(path_to_datapackage)
     for name, df in dict_of_dataframes.items():
         write_out_dataframe(path_to_datapackage, name, df)
+    datapackage = read_datapackage()
+    filepath = os.path.join(path_to_datapackage, 'datapackage.json')
+    with open(filepath, 'w') as destination:
+        destination.writelines(datapackage)
 
 
 def read_in_datafile(path_to_datafile: str, config: Dict) -> Amply:

--- a/src/otoole/preprocess/datapackage.json
+++ b/src/otoole/preprocess/datapackage.json
@@ -1,0 +1,3389 @@
+{
+    "profile": "tabular-data-package",
+    "resources": [
+        {
+            "path": "data/MODE_OF_OPERATION.csv",
+            "profile": "tabular-data-resource",
+            "name": "MODE_OF_OPERATION",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/AnnualExogenousEmission.csv",
+            "profile": "tabular-data-resource",
+            "name": "AnnualExogenousEmission",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "EMISSION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/AccumulatedAnnualDemand.csv",
+            "profile": "tabular-data-resource",
+            "name": "AccumulatedAnnualDemand",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalAnnualMaxCapacity.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalAnnualMaxCapacity",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/CapacityToActivityUnit.csv",
+            "profile": "tabular-data-resource",
+            "name": "CapacityToActivityUnit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY"
+                ]
+            }
+        },
+        {
+            "path": "data/StorageMaxChargeRate.csv",
+            "profile": "tabular-data-resource",
+            "name": "StorageMaxChargeRate",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE"
+                ]
+            }
+        },
+        {
+            "path": "data/DiscountRate.csv",
+            "profile": "tabular-data-resource",
+            "name": "DiscountRate",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0.05"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalTechnologyAnnualActivityLowerLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalTechnologyAnnualActivityLowerLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/ResidualStorageCapacity.csv",
+            "profile": "tabular-data-resource",
+            "name": "ResidualStorageCapacity",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/OutputActivityRatio.csv",
+            "profile": "tabular-data-resource",
+            "name": "OutputActivityRatio",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "FUEL",
+                    "MODE_OF_OPERATION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/EMISSION.csv",
+            "profile": "tabular-data-resource",
+            "name": "EMISSION",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/RETagFuel.csv",
+            "profile": "tabular-data-resource",
+            "name": "RETagFuel",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/FixedCost.csv",
+            "profile": "tabular-data-resource",
+            "name": "FixedCost",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/EmissionActivityRatio.csv",
+            "profile": "tabular-data-resource",
+            "name": "EmissionActivityRatio",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "EMISSION",
+                    "MODE_OF_OPERATION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/RETagTechnology.csv",
+            "profile": "tabular-data-resource",
+            "name": "RETagTechnology",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/YearSplit.csv",
+            "profile": "tabular-data-resource",
+            "name": "YearSplit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "TIMESLICE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/Conversionlh.csv",
+            "profile": "tabular-data-resource",
+            "name": "Conversionlh",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "DAILYTIMEBRACKET",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "DAILYTIMEBRACKET",
+                        "reference": {
+                            "resource": "DAILYTIMEBRACKET",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "TIMESLICE",
+                    "DAILYTIMEBRACKET"
+                ]
+            }
+        },
+        {
+            "path": "data/DaySplit.csv",
+            "profile": "tabular-data-resource",
+            "name": "DaySplit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "DAILYTIMEBRACKET",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0.00137"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "DAILYTIMEBRACKET",
+                        "reference": {
+                            "resource": "DAILYTIMEBRACKET",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "DAILYTIMEBRACKET",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/MinStorageCharge.csv",
+            "profile": "tabular-data-resource",
+            "name": "MinStorageCharge",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/VariableCost.csv",
+            "profile": "tabular-data-resource",
+            "name": "VariableCost",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "MODE_OF_OPERATION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/CapitalCostStorage.csv",
+            "profile": "tabular-data-resource",
+            "name": "CapitalCostStorage",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/ResidualCapacity.csv",
+            "profile": "tabular-data-resource",
+            "name": "ResidualCapacity",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/DAYTYPE.csv",
+            "profile": "tabular-data-resource",
+            "name": "DAYTYPE",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/StorageLevelStart.csv",
+            "profile": "tabular-data-resource",
+            "name": "StorageLevelStart",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE"
+                ]
+            }
+        },
+        {
+            "path": "data/TECHNOLOGY.csv",
+            "profile": "tabular-data-resource",
+            "name": "TECHNOLOGY",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/InputActivityRatio.csv",
+            "profile": "tabular-data-resource",
+            "name": "InputActivityRatio",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "FUEL",
+                    "MODE_OF_OPERATION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/OperationalLife.csv",
+            "profile": "tabular-data-resource",
+            "name": "OperationalLife",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY"
+                ]
+            }
+        },
+        {
+            "path": "data/AnnualEmissionLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "AnnualEmissionLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "EMISSION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/ModelPeriodEmissionLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "ModelPeriodEmissionLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "EMISSION"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalTechnologyAnnualActivityUpperLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalTechnologyAnnualActivityUpperLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TechnologyToStorage.csv",
+            "profile": "tabular-data-resource",
+            "name": "TechnologyToStorage",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "STORAGE",
+                    "MODE_OF_OPERATION"
+                ]
+            }
+        },
+        {
+            "path": "data/ReserveMarginTagFuel.csv",
+            "profile": "tabular-data-resource",
+            "name": "ReserveMarginTagFuel",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/OperationalLifeStorage.csv",
+            "profile": "tabular-data-resource",
+            "name": "OperationalLifeStorage",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE"
+                ]
+            }
+        },
+        {
+            "path": "data/STORAGE.csv",
+            "profile": "tabular-data-resource",
+            "name": "STORAGE",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/ModelPeriodExogenousEmission.csv",
+            "profile": "tabular-data-resource",
+            "name": "ModelPeriodExogenousEmission",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "EMISSION"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalAnnualMaxCapacityInvestment.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalAnnualMaxCapacityInvestment",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/SpecifiedDemandProfile.csv",
+            "profile": "tabular-data-resource",
+            "name": "SpecifiedDemandProfile",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "TIMESLICE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalAnnualMinCapacity.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalAnnualMinCapacity",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/YEAR.csv",
+            "profile": "tabular-data-resource",
+            "name": "YEAR",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/FUEL.csv",
+            "profile": "tabular-data-resource",
+            "name": "FUEL",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/TotalTechnologyModelPeriodActivityLowerLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalTechnologyModelPeriodActivityLowerLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY"
+                ]
+            }
+        },
+        {
+            "path": "data/ReserveMarginTagTechnology.csv",
+            "profile": "tabular-data-resource",
+            "name": "ReserveMarginTagTechnology",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/StorageMaxDischargeRate.csv",
+            "profile": "tabular-data-resource",
+            "name": "StorageMaxDischargeRate",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "STORAGE"
+                ]
+            }
+        },
+        {
+            "path": "data/TradeRoute.csv",
+            "profile": "tabular-data-resource",
+            "name": "TradeRoute",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/CapacityFactor.csv",
+            "profile": "tabular-data-resource",
+            "name": "CapacityFactor",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "TIMESLICE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/DepreciationMethod.csv",
+            "profile": "tabular-data-resource",
+            "name": "DepreciationMethod",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION"
+                ]
+            }
+        },
+        {
+            "path": "data/DaysInDayType.csv",
+            "profile": "tabular-data-resource",
+            "name": "DaysInDayType",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "SEASON",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "DAYTYPE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "7"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "SEASON",
+                        "reference": {
+                            "resource": "SEASON",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "DAYTYPE",
+                        "reference": {
+                            "resource": "DAYTYPE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "SEASON",
+                    "DAYTYPE",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/Conversionld.csv",
+            "profile": "tabular-data-resource",
+            "name": "Conversionld",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "DAYTYPE",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "DAYTYPE",
+                        "reference": {
+                            "resource": "DAYTYPE",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "TIMESLICE",
+                    "DAYTYPE"
+                ]
+            }
+        },
+        {
+            "path": "data/Conversionls.csv",
+            "profile": "tabular-data-resource",
+            "name": "Conversionls",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "TIMESLICE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "SEASON",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "TIMESLICE",
+                        "reference": {
+                            "resource": "TIMESLICE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "SEASON",
+                        "reference": {
+                            "resource": "SEASON",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "TIMESLICE",
+                    "SEASON"
+                ]
+            }
+        },
+        {
+            "path": "data/SEASON.csv",
+            "profile": "tabular-data-resource",
+            "name": "SEASON",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/DAILYTIMEBRACKET.csv",
+            "profile": "tabular-data-resource",
+            "name": "DAILYTIMEBRACKET",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "integer",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/AvailabilityFactor.csv",
+            "profile": "tabular-data-resource",
+            "name": "AvailabilityFactor",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/SpecifiedAnnualDemand.csv",
+            "profile": "tabular-data-resource",
+            "name": "SpecifiedAnnualDemand",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "FUEL",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "FUEL",
+                        "reference": {
+                            "resource": "FUEL",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "FUEL",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TIMESLICE.csv",
+            "profile": "tabular-data-resource",
+            "name": "TIMESLICE",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/CapitalCost.csv",
+            "profile": "tabular-data-resource",
+            "name": "CapitalCost",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/REGION.csv",
+            "profile": "tabular-data-resource",
+            "name": "REGION",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/ReserveMargin.csv",
+            "profile": "tabular-data-resource",
+            "name": "ReserveMargin",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "1"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalAnnualMinCapacityInvestment.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalAnnualMinCapacityInvestment",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TotalTechnologyModelPeriodActivityUpperLimit.csv",
+            "profile": "tabular-data-resource",
+            "name": "TotalTechnologyModelPeriodActivityUpperLimit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "99999"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY"
+                ]
+            }
+        },
+        {
+            "path": "data/REMinProductionTarget.csv",
+            "profile": "tabular-data-resource",
+            "name": "REMinProductionTarget",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/CapacityOfOneTechnologyUnit.csv",
+            "profile": "tabular-data-resource",
+            "name": "CapacityOfOneTechnologyUnit",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/EmissionsPenalty.csv",
+            "profile": "tabular-data-resource",
+            "name": "EmissionsPenalty",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "EMISSION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "YEAR",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "EMISSION",
+                        "reference": {
+                            "resource": "EMISSION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "YEAR",
+                        "reference": {
+                            "resource": "YEAR",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "EMISSION",
+                    "YEAR"
+                ]
+            }
+        },
+        {
+            "path": "data/TechnologyFromStorage.csv",
+            "profile": "tabular-data-resource",
+            "name": "TechnologyFromStorage",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "TECHNOLOGY",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "STORAGE",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "MODE_OF_OPERATION",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    "0"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "TECHNOLOGY",
+                        "reference": {
+                            "resource": "TECHNOLOGY",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "STORAGE",
+                        "reference": {
+                            "resource": "STORAGE",
+                            "fields": "VALUE"
+                        }
+                    },
+                    {
+                        "fields": "MODE_OF_OPERATION",
+                        "reference": {
+                            "resource": "MODE_OF_OPERATION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION",
+                    "TECHNOLOGY",
+                    "STORAGE",
+                    "MODE_OF_OPERATION"
+                ]
+            }
+        }
+    ],
+    "licenses": [
+        {
+            "name": "CC-BY-4.0",
+            "path": "https://creativecommons.org/licenses/by/4.0/",
+            "title": "Creative Commons Attribution 4.0"
+        }
+    ],
+    "title": "The OSeMOSYS Simplicity Example Model",
+    "name": "osemosys_model_simplicity",
+    "id": "https://doi.org/10.5281/zenodo.3479822",
+    "contributors": [
+        {
+            "title": "Will Usher",
+            "email": "wusher@kth.se",
+            "path": "https://www.kth.se/profile/wusher/",
+            "role": "author"
+        }
+    ]
+}

--- a/src/otoole/preprocess/excel_to_osemosys.py
+++ b/src/otoole/preprocess/excel_to_osemosys.py
@@ -167,7 +167,7 @@ param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 import csv
 import logging
 import os
-from typing import List
+from typing import Dict, List
 
 import xlrd
 from yaml import SafeLoader, load
@@ -181,8 +181,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def read_config():
+def read_config() -> Dict:
+    """Reads the config file holding expected OSeMOSYS set and parameter dimensions
 
+    Returns
+    -------
+    dict
+    """
     with pkg_resources.open_text('otoole.preprocess', 'config.yaml') as config_file:
         config = load(config_file, Loader=SafeLoader)
     return config

--- a/src/otoole/preprocess/excel_to_osemosys.py
+++ b/src/otoole/preprocess/excel_to_osemosys.py
@@ -181,15 +181,24 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def read_config() -> Dict:
+def read_config(path_to_user_config: str = None) -> Dict:
     """Reads the config file holding expected OSeMOSYS set and parameter dimensions
+
+    Arguments
+    ---------
+    path_to_user_config : str, optional, default=None
+        Optional path to a user defined configuration file
 
     Returns
     -------
     dict
     """
-    with pkg_resources.open_text('otoole.preprocess', 'config.yaml') as config_file:
-        config = load(config_file, Loader=SafeLoader)
+    if path_to_user_config:
+        with open(path_to_user_config, 'r') as user_config_file:
+            config = load(user_config_file, Loader=SafeLoader)
+    else:
+        with pkg_resources.open_text('otoole.preprocess', 'config.yaml') as config_file:
+            config = load(config_file, Loader=SafeLoader)
     return config
 
 

--- a/src/otoole/preprocess/excel_to_osemosys.py
+++ b/src/otoole/preprocess/excel_to_osemosys.py
@@ -9,23 +9,26 @@ Notes
 =====
 
 Sets
-~~~~
-set YEAR;
-set TECHNOLOGY;
-set TIMESLICE;
-set FUEL;
-set EMISSION;
-set MODE_OF_OPERATION;
-set REGION;
-set SEASON;
-set DAYTYPE;
-set DAILYTIMEBRACKET;
-set FLEXIBLEDEMANDTYPE;
-set STORAGE;
+----
+These are the standard sets::
 
-All sets are written in a CSV file in one column of values with no header.
+    set YEAR;
+    set TECHNOLOGY;
+    set TIMESLICE;
+    set FUEL;
+    set EMISSION;
+    set MODE_OF_OPERATION;
+    set REGION;
+    set SEASON;
+    set DAYTYPE;
+    set DAILYTIMEBRACKET;
+    set FLEXIBLEDEMANDTYPE;
+    set STORAGE;
+
+All sets are written in a CSV file in one column of values with header of ``VALUE``.
 For example, the CSV file for set YEAR::
 
+    VALUE
     2015
     2016
     2017
@@ -37,29 +40,30 @@ Sets are written into the OSeMOSYS data file using the following syntax::
 
     set YEAR := 2014 2015 2016 2017 2018 2019 2020 ;
 
-Parameters
-~~~~~~~~~~
 
+Parameters
+----------
 In general, parameters can be written into CSV files in narrow or wide
 formats. In narrow format, the CSV file should look as follows::
 
-    TIMESLICE,YEAR,VALUE
-    ID,2014,0.1667
-    IN,2014,0.0833
-    SD,2014,0.1667
-    SN,2014,0.0833
-    WD,2014,0.3333
-    WN,2014,0.1667
+    REGION,TIMESLICE,YEAR,VALUE
+    SIMPLICITY,ID,2014,0.1667
+    SIMPLICITY,IN,2014,0.0833
+    SIMPLICITY,SD,2014,0.1667
+    SIMPLICITY,SN,2014,0.0833
+    SIMPLICITY,WD,2014,0.3333
+    SIMPLICITY,WN,2014,0.1667
+
 
 In wide format, the final index is transposed::
 
-    TIMESLICE,2014,2015,...
-    ID,0.1667,0.1667
-    IN,0.0833,0.0833
-    SD,0.1667,0.1667
-    SN,0.0833,0.0833
-    WD,0.3333,0.3333
-    WN,0.1667,0.1667
+    REGION,TIMESLICE,2014,2015,...
+    SIMPLICITY,ID,0.1667,0.1667
+    SIMPLICITY,IN,0.0833,0.0833
+    SIMPLICITY,SD,0.1667,0.1667
+    SIMPLICITY,SN,0.0833,0.0833
+    SIMPLICITY,WD,0.3333,0.3333
+    SIMPLICITY,WN,0.1667,0.1667
 
 Wide format is a bit nicer to use with spreadsheets,
 as it allows you to more easily plot graphs of values, but narrow
@@ -74,94 +78,101 @@ Writing parameteters:
 n-dimensional e.g. DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR}
 
 
+Global parameters::
 
-Global
-------
-param YearSplit{l in TIMESLICE, y in YEAR};
-param DiscountRate{r in REGION};
-param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
-param Conversionls{l in TIMESLICE, ls in SEASON};
-param Conversionld{l in TIMESLICE, ld in DAYTYPE};
-param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
-param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
-param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR};
-param DepreciationMethod{r in REGION};
+    param YearSplit{l in TIMESLICE, y in YEAR};
+    param DiscountRate{r in REGION};
+    param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
+    param Conversionls{l in TIMESLICE, ls in SEASON};
+    param Conversionld{l in TIMESLICE, ld in DAYTYPE};
+    param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
+    param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
+    param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR};
+    param DepreciationMethod{r in REGION};
 
-Demands
--------
-param SpecifiedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
-param SpecifiedDemandProfile{r in REGION, f in FUEL, l in TIMESLICE, y in YEAR};
-param AccumulatedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
 
-Performance
------------
+Demand parameters::
 
-param CapacityToActivityUnit{r in REGION, t in TECHNOLOGY};
-param TechWithCapacityNeededToMeetPeakTS{r in REGION, t in TECHNOLOGY};
-param CapacityFactor{r in REGION, t in TECHNOLOGY, l in TIMESLICE, y in YEAR};
-param AvailabilityFactor{r in REGION, t in TECHNOLOGY, y in YEAR};
-param OperationalLife{r in REGION, t in TECHNOLOGY};
-param ResidualCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
-param InputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
-param OutputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
+    param SpecifiedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
+    param SpecifiedDemandProfile{r in REGION, f in FUEL, l in TIMESLICE, y in YEAR};
+    param AccumulatedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
 
-Technology Costs
-----------------
-param CapitalCost{r in REGION, t in TECHNOLOGY, y in YEAR};
-param VariableCost{r in REGION, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR};
-param FixedCost{r in REGION, t in TECHNOLOGY, y in YEAR};
 
-Storage
--------
-param TechnologyToStorage{r in REGION, t in TECHNOLOGY, s in STORAGE, m in MODE_OF_OPERATION};
-param TechnologyFromStorage{r in REGION, t in TECHNOLOGY, s in STORAGE, m in MODE_OF_OPERATION};
-param StorageLevelStart{r in REGION, s in STORAGE};
-param StorageMaxChargeRate{r in REGION, s in STORAGE};
-param StorageMaxDischargeRate{r in REGION, s in STORAGE};
-param MinStorageCharge{r in REGION, s in STORAGE, y in YEAR};
-param OperationalLifeStorage{r in REGION, s in STORAGE};
-param CapitalCostStorage{r in REGION, s in STORAGE, y in YEAR};
-param ResidualStorageCapacity{r in REGION, s in STORAGE, y in YEAR};
+Performance parameters::
 
-Capacity Constraints
---------------------
-param CapacityOfOneTechnologyUnit{r in REGION, t in TECHNOLOGY, y in YEAR};
-param TotalAnnualMaxCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
-param TotalAnnualMinCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param CapacityToActivityUnit{r in REGION, t in TECHNOLOGY};
+    param TechWithCapacityNeededToMeetPeakTS{r in REGION, t in TECHNOLOGY};
+    param CapacityFactor{r in REGION, t in TECHNOLOGY, l in TIMESLICE, y in YEAR};
+    param AvailabilityFactor{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param OperationalLife{r in REGION, t in TECHNOLOGY};
+    param ResidualCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param InputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
+    param OutputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
 
-Investment Constraints
-----------------------
-param TotalAnnualMaxCapacityInvestment{r in REGION, t in TECHNOLOGY, y in YEAR};
-param TotalAnnualMinCapacityInvestment{r in REGION, t in TECHNOLOGY, y in YEAR};
 
-Activity Constraints
---------------------
-param TotalTechnologyAnnualActivityUpperLimit{r in REGION, t in TECHNOLOGY, y in YEAR};
-param TotalTechnologyAnnualActivityLowerLimit{r in REGION, t in TECHNOLOGY, y in YEAR};
-param TotalTechnologyModelPeriodActivityUpperLimit{r in REGION, t in TECHNOLOGY};
-param TotalTechnologyModelPeriodActivityLowerLimit{r in REGION, t in TECHNOLOGY};
+Technology Costs parameters::
 
-Reserve Margin
---------------
-param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR};
-param ReserveMargin{r in REGION, y in YEAR};
+    param CapitalCost{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param VariableCost{r in REGION, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR};
+    param FixedCost{r in REGION, t in TECHNOLOGY, y in YEAR};
 
-RE Generation Target
---------------------
-param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param RETagFuel{r in REGION, f in FUEL, y in YEAR};
-param REMinProductionTarget{r in REGION, y in YEAR};
 
-Emissions & Penalties
----------------------
-param EmissionActivityRatio{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODE_OF_OPERATION, y in YEAR};
-param EmissionsPenalty{r in REGION, e in EMISSION, y in YEAR};
-param AnnualExogenousEmission{r in REGION, e in EMISSION, y in YEAR};
-param AnnualEmissionLimit{r in REGION, e in EMISSION, y in YEAR};
-param ModelPeriodExogenousEmission{r in REGION, e in EMISSION};
-param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
+Storage parameters::
 
+    param TechnologyToStorage{r in REGION, t in TECHNOLOGY, s in STORAGE, m in MODE_OF_OPERATION};
+    param TechnologyFromStorage{r in REGION, t in TECHNOLOGY, s in STORAGE, m in MODE_OF_OPERATION};
+    param StorageLevelStart{r in REGION, s in STORAGE};
+    param StorageMaxChargeRate{r in REGION, s in STORAGE};
+    param StorageMaxDischargeRate{r in REGION, s in STORAGE};
+    param MinStorageCharge{r in REGION, s in STORAGE, y in YEAR};
+    param OperationalLifeStorage{r in REGION, s in STORAGE};
+    param CapitalCostStorage{r in REGION, s in STORAGE, y in YEAR};
+    param ResidualStorageCapacity{r in REGION, s in STORAGE, y in YEAR};
+
+
+Capacity Constraints parameters::
+
+    param CapacityOfOneTechnologyUnit{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param TotalAnnualMaxCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param TotalAnnualMinCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
+
+
+Investment Constraints parameters::
+
+    param TotalAnnualMaxCapacityInvestment{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param TotalAnnualMinCapacityInvestment{r in REGION, t in TECHNOLOGY, y in YEAR};
+
+
+Activity Constraints parameters::
+
+    param TotalTechnologyAnnualActivityUpperLimit{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param TotalTechnologyAnnualActivityLowerLimit{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param TotalTechnologyModelPeriodActivityUpperLimit{r in REGION, t in TECHNOLOGY};
+    param TotalTechnologyModelPeriodActivityLowerLimit{r in REGION, t in TECHNOLOGY};
+
+
+Reserve Margin parameters::
+
+    param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR};
+    param ReserveMargin{r in REGION, y in YEAR};
+
+
+RE Generation Target parameters::
+
+    param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
+    param RETagFuel{r in REGION, f in FUEL, y in YEAR};
+    param REMinProductionTarget{r in REGION, y in YEAR};
+
+
+Emissions & Penalties parameters::
+
+    param EmissionActivityRatio{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODE_OF_OPERATION, y in YEAR};
+    param EmissionsPenalty{r in REGION, e in EMISSION, y in YEAR};
+    param AnnualExogenousEmission{r in REGION, e in EMISSION, y in YEAR};
+    param AnnualEmissionLimit{r in REGION, e in EMISSION, y in YEAR};
+    param ModelPeriodExogenousEmission{r in REGION, e in EMISSION};
+    param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 
 """
 import csv

--- a/src/otoole/preprocess/excel_to_osemosys.py
+++ b/src/otoole/preprocess/excel_to_osemosys.py
@@ -192,6 +192,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def read_datapackage():
+    with pkg_resources.open_text('otoole.preprocess', 'datapackage.json') as json_file:
+        json = json_file.readlines()
+    return json
+
+
 def read_config(path_to_user_config: str = None) -> Dict:
     """Reads the config file holding expected OSeMOSYS set and parameter dimensions
 

--- a/src/otoole/preprocess/longify_data.py
+++ b/src/otoole/preprocess/longify_data.py
@@ -140,10 +140,23 @@ def main(output_folder, narrow_folder):
             else:
                 narrow_checked = narrow
 
-        filepath = os.path.join(narrow_folder, 'data', parameter + '.csv')
-        with open(filepath, 'w') as csvfile:
-            logger.info("Writing %s rows into narrow file for %s", narrow_checked.shape[0], parameter)
-            narrow_checked.to_csv(csvfile, index=False)
+        write_out_dataframe(narrow_folder, parameter, narrow_checked)
+
+
+def write_out_dataframe(folder, parameter, df):
+    """
+
+    Arguments
+    ---------
+    folder : str
+    parameter : str
+    df : pandas.DataFrame
+
+    """
+    filepath = os.path.join(folder, 'data', parameter + '.csv')
+    with open(filepath, 'w') as csvfile:
+        logger.info("Writing %s rows into narrow file for %s", df.shape[0], parameter)
+        df.to_csv(csvfile, index=False)
 
 
 if __name__ == '__main__':

--- a/src/otoole/preprocess/longify_data.py
+++ b/src/otoole/preprocess/longify_data.py
@@ -95,14 +95,14 @@ def check_datatypes(narrow: pd.DataFrame, config_details: Dict, parameter: str) 
             logger.warning("dtype of column %s does not match %s for parameter %s", column, datatype, parameter)
             if datatype == 'int':
                 try:
-                    narrow[column] = narrow[column].apply(cast_to_int)
+                    narrow[column] = narrow[column].apply(_cast_to_int)
                 except ValueError as ex:
                     msg = "Unable to apply datatype for column {}: {}".format(column, str(ex))
                     raise ValueError(msg)
     return narrow.astype(dtypes)
 
 
-def cast_to_int(value):
+def _cast_to_int(value):
     return int(float(value))
 
 
@@ -144,7 +144,7 @@ def main(output_folder, narrow_folder):
 
 
 def write_out_dataframe(folder, parameter, df):
-    """
+    """Writes out a dataframe as a csv into the data subfolder of a datapackage
 
     Arguments
     ---------

--- a/src/otoole/preprocess/longify_data.py
+++ b/src/otoole/preprocess/longify_data.py
@@ -153,6 +153,7 @@ def write_out_dataframe(folder, parameter, df):
     df : pandas.DataFrame
 
     """
+    os.makedirs(os.path.join(folder, 'data'), exist_ok=True)
     filepath = os.path.join(folder, 'data', parameter + '.csv')
     with open(filepath, 'w') as csvfile:
         logger.info("Writing %s rows into narrow file for %s", df.shape[0], parameter)

--- a/src/otoole/preprocess/longify_data.py
+++ b/src/otoole/preprocess/longify_data.py
@@ -50,16 +50,36 @@ def check_set(df, config_details, name):
     return narrow
 
 
-def check_set_datatype(narrow: pd.DataFrame, config_details: Dict, parameter: str) -> pd.DataFrame:
-    datatype = config_details[parameter]['dtype']
-    logger.debug('Columns for set %s are: %s', parameter, narrow.columns)
+def check_set_datatype(narrow: pd.DataFrame, config_details: Dict, set_name: str) -> pd.DataFrame:
+    """Checks the datatypes of a set_name dataframe
+
+    Arguments
+    ---------
+    narrow : pandas.DataFrame
+        The set data
+    config_details : dict
+        The configuration dictionary
+    set_name : str
+        The name of the set
+    """
+    datatype = config_details[set_name]['dtype']
+    logger.debug('Columns for set %s are: %s', set_name, narrow.columns)
     if narrow.iloc[:, 0].dtype != datatype:
-        logger.warning("dtype does not match %s for set %s", datatype, parameter)
+        logger.warning("dtype does not match %s for set %s", datatype, set_name)
     return narrow
 
 
 def check_datatypes(narrow: pd.DataFrame, config_details: Dict, parameter: str) -> pd.DataFrame:
-    """
+    """Checks a parameters datatypes
+
+    Arguments
+    ---------
+    narrow : pandas.DataFrame
+        The parameter data
+    config_details : dict
+        The configuration dictionary
+    parameter : str
+        The name of the parameter
     """
     logger.info("Checking datatypes for %s", parameter)
     dtypes = {}
@@ -74,7 +94,11 @@ def check_datatypes(narrow: pd.DataFrame, config_details: Dict, parameter: str) 
         if narrow[column].dtype != datatype:
             logger.warning("dtype of column %s does not match %s for parameter %s", column, datatype, parameter)
             if datatype == 'int':
-                narrow[column] = narrow[column].apply(cast_to_int)
+                try:
+                    narrow[column] = narrow[column].apply(cast_to_int)
+                except ValueError as ex:
+                    msg = "Unable to apply datatype for column {}: {}".format(column, str(ex))
+                    raise ValueError(msg)
     return narrow.astype(dtypes)
 
 

--- a/tests/preprocess/test_file2package.py
+++ b/tests/preprocess/test_file2package.py
@@ -1,8 +1,95 @@
-from otoole.preprocess import convert_file_to_package
+import pandas as pd
+from pulp.amply import Amply
+
+from otoole.preprocess.datafile_to_datapackage import (
+    convert_amply_data_to_list,
+    convert_amply_to_dataframe,
+    load_parameter_definitions
+)
 
 
-def test_convert_file_to_package():
+def test_convert_amply_to_dataframe():
 
-    convert_file_to_package('test.txt', 'test_package')
+    config = {'VariableCost': {'type': 'param',
+                               'indices': ['REGION', 'TECHNOLOGY', 'MODE_OF_OPERATION', 'YEAR'],
+                               'dtype': 'float',
+                               'default': 0},
+              'REGION': {'type': 'set', 'dtype': 'str'},
+              'YEAR': {'dtype': 'int', 'type': 'set'},
+              'MODE_OF_OPERATION': {'dtype': 'int', 'type': 'set'},
+              'TECHNOLOGY': {'dtype': 'str', 'type': 'set'}}
 
-    pass
+    amply = Amply("""set REGION;
+                     set REGION := SIMPLICITY;
+                     set TECHNOLOGY;
+                     set TECHNOLOGY := ETHPLANT GAS_EXTRACTION;
+                     set MODE_OF_OPERATION;
+                     set MODE_OF_OPERATION := 1 2;
+                     set YEAR;
+                     set YEAR := 2014;""")
+    amply.load_string(
+        "param VariableCost {REGION,TECHNOLOGY,MODE_OF_OPERATION,YEAR};")
+#     amply.load_string("""param default 0 : VariableCost :=
+# SIMPLICITY ETHPLANT 1 2014 2.89
+# SIMPLICITY ETHPLANT 2 2014 999999.0
+# SIMPLICITY GAS_EXTRACTION 1 2014 7.5
+# SIMPLICITY GAS_EXTRACTION 2 2014 999999.0""")
+    amply.load_string("""
+param VariableCost default 0.0001 :=
+[SIMPLICITY,ETHPLANT,*,*]:
+2014 :=
+1 2.89
+2 999999.0
+[SIMPLICITY,GAS_EXTRACTION,*,*]:
+2014 :=
+1 7.5
+2 999999.0;""")
+    actual = convert_amply_to_dataframe(amply, config)
+    expected = pd.DataFrame(
+        data=[['SIMPLICITY', 'ETHPLANT', 1, 2014, 2.89],
+              ['SIMPLICITY', 'ETHPLANT', 2, 2014, 999999.0],
+              ['SIMPLICITY', 'GAS_EXTRACTION', 1, 2014, 7.5],
+              ['SIMPLICITY', 'GAS_EXTRACTION', 2, 2014, 999999.0]],
+        columns=['REGION', 'TECHNOLOGY', 'MODE_OF_OPERATION', 'YEAR', 'VALUE'])
+
+    pd.testing.assert_frame_equal(actual['VariableCost'], expected)
+
+
+def test_convert_amply_data_to_list_of_lists():
+
+    data = {'SIMPLICITY': {
+        'ETHPLANT': {
+            1.0: {2014.0: 2.89},
+            2.0: {2014.0: 999999.0}},
+        'GAS_EXTRACTION': {
+            1.0: {2014.0: 7.5},
+            2.0: {2014.0: 999999.0}},
+                            }
+            }
+    expected = [['SIMPLICITY', 'ETHPLANT', 1.0, 2014.0, 2.89],
+                ['SIMPLICITY', 'ETHPLANT', 2.0, 2014.0, 999999.0],
+                ['SIMPLICITY', 'GAS_EXTRACTION', 1.0, 2014.0, 7.5],
+                ['SIMPLICITY', 'GAS_EXTRACTION', 2.0, 2014.0, 999999.0]]
+    actual = convert_amply_data_to_list(data)
+    assert actual == expected
+
+
+def test_load_parameters():
+
+    config = {
+        'TestParameter': {'type': 'param',
+                          'indices': ['index1', 'index2']}}
+
+    actual = load_parameter_definitions(config)
+    expected = 'param TestParameter {index1,index2};\n'
+    assert actual == expected
+
+
+def test_load_sets():
+
+    config = {
+        'TestSet': {'type': 'set'}}
+
+    actual = load_parameter_definitions(config)
+    expected = 'set TestSet;\n'
+    assert actual == expected

--- a/tests/preprocess/test_file2package.py
+++ b/tests/preprocess/test_file2package.py
@@ -1,0 +1,8 @@
+from otoole.preprocess import convert_file_to_package
+
+
+def test_convert_file_to_package():
+
+    convert_file_to_package('test.txt', 'test_package')
+
+    pass


### PR DESCRIPTION
Closes #5

Uses the PuLP.amply module to read in parameters and sets from an OSeMOSYS datafile, converts the data to narrow and well-formatted pandas DataFrames, and writes these out into a folder.

There are a number of outstanding issues with this approach:

- the amply module does not read in tabbing format tables from a datafile (see https://github.com/coin-or/pulp/issues/231)
- the CLI is now a bit of a jungle
- [x] need to add automated writing of the `datapackage.json`
- further checking of datatypes and better error messages