### PR TITLE
Adds a validate function to the command line interface

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyyaml
     pydot
     importlib_resources; python_version<'3.7'
-    datapackage
+    datapackage~=1.9
     pandas
     pulp
     networkx

--- a/src/otoole/__init__.py
+++ b/src/otoole/__init__.py
@@ -2,6 +2,8 @@
 from pkg_resources import get_distribution, DistributionNotFound
 import os
 from yaml import SafeLoader, load
+from datapackage import Package
+from sqlalchemy import create_engine
 
 try:
     import importlib.resources as resources
@@ -39,3 +41,22 @@ def read_packaged_file(filename: str, module_name: str = None):
             contents = _read_file(open_file, ending)
 
     return contents
+
+
+def read_datapackage(filepath: str, sql: bool = False):
+    """Open an OSeMOSYS datapackage
+
+    Arguments
+    ---------
+    filepath : str
+    sql : bool, default=False
+    """
+    if sql:
+        engine = create_engine('sqlite:///{}'.format(filepath))
+        package = Package(storage='sql', engine=engine)
+    else:
+        package = Package(filepath)
+
+    package.infer()
+
+    return package

--- a/src/otoole/__init__.py
+++ b/src/otoole/__init__.py
@@ -54,9 +54,8 @@ def read_datapackage(filepath: str, sql: bool = False):
     if sql:
         engine = create_engine('sqlite:///{}'.format(filepath))
         package = Package(storage='sql', engine=engine)
+        package.infer()
     else:
         package = Package(filepath)
-
-    package.infer()
 
     return package

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -41,7 +41,13 @@ from otoole import __version__
 from otoole.preprocess import convert_file_to_package, create_datafile, create_datapackage, generate_csv_from_excel
 from otoole.preprocess.create_datapackage import convert_datapackage_to_sqlite
 from otoole.results.convert import convert_cplex_file
+from otoole.validate import main as validate
 from otoole.visualise import create_res
+
+
+def validate_model(args):
+    file_format = args.format
+    validate(file_format, args.filepath)
 
 
 def cplex2cbc(args):
@@ -50,13 +56,17 @@ def cplex2cbc(args):
 
 
 def conversion_matrix(args):
-    """
-    from\to     ex cs dp sq df
-    excel       -- yy
-    csv         nn -- yy nn nn
-    datapackage nn ?? -- yy yy
-    sql         nn       -- yy
-    datafile    nn ?? yy    --
+    """Convert from one format to another
+
+    Implemented conversion functions::
+
+        from\to     ex cs dp sq df
+        --------------------------
+        excel       -- yy
+        csv         nn -- yy nn nn
+        datapackage nn ?? -- yy yy
+        sql         nn       -- yy
+        datafile    nn ?? yy    --
 
     """
 
@@ -138,6 +148,12 @@ def get_parser():
                               help="Output only the results upto and including this year")
     cplex_parser.add_argument('output_format', choices=['csv', 'cbc'], default='cbc')
     cplex_parser.set_defaults(func=cplex2cbc)
+
+    # Parser for validation
+    valid_parser = subparsers.add_parser('validate', help='Validate an OSeMOSYS model')
+    valid_parser.add_argument('format', help='The format of the OSeMOSYS model to validate')
+    valid_parser.add_argument('filepath', help='Path to the OSeMOSYS model to validate')
+    valid_parser.set_defaults(func=validate_model)
 
     # Parser for visualisation
     viz_parser = subparsers.add_parser('viz', help='Visualise the model')

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -37,7 +37,7 @@ import argparse
 import logging
 import sys
 
-from otoole import __version__
+from otoole import __version__, read_packaged_file
 from otoole.preprocess import convert_file_to_package, create_datafile, create_datapackage, generate_csv_from_excel
 from otoole.preprocess.create_datapackage import convert_datapackage_to_sqlite
 from otoole.results.convert import convert_cplex_file
@@ -47,7 +47,12 @@ from otoole.visualise import create_res
 
 def validate_model(args):
     file_format = args.format
-    validate(file_format, args.filepath)
+
+    if args.config:
+        config = read_packaged_file(args.config)
+        validate(file_format, args.filepath, config)
+    else:
+        validate(file_format, args.filepath)
 
 
 def cplex2cbc(args):
@@ -153,6 +158,7 @@ def get_parser():
     valid_parser = subparsers.add_parser('validate', help='Validate an OSeMOSYS model')
     valid_parser.add_argument('format', help='The format of the OSeMOSYS model to validate')
     valid_parser.add_argument('filepath', help='Path to the OSeMOSYS model to validate')
+    valid_parser.add_argument('--config', help='Path to a user-defined validation-config file')
     valid_parser.set_defaults(func=validate_model)
 
     # Parser for visualisation

--- a/src/otoole/validate.py
+++ b/src/otoole/validate.py
@@ -164,7 +164,7 @@ def identify_orphaned_fuels_techs(package) -> Dict[str, str]:
     return isolated_nodes
 
 
-def main(file_format: str, filepath: str):
+def main(file_format: str, filepath: str, config=None):
 
     print("\n***Beginning validation***")
     if file_format == 'datapackage':
@@ -172,7 +172,7 @@ def main(file_format: str, filepath: str):
     elif file_format == 'sql':
         package = read_datapackage(filepath, sql=True)
 
-    schema = create_schema()
+    schema = create_schema(config)
 
     print("\n***Checking TECHNOLOGY names***\n")
     validate_resource(package, schema['technology_name'], 'TECHNOLOGY')

--- a/src/otoole/validate.yaml
+++ b/src/otoole/validate.yaml
@@ -1,125 +1,122 @@
 codes:
-  emissions:
-    REN: Emission factor that was used to model the RET targets for each country
-    CO2: Emission factor for CO2
-    CH4: Emission factor for methane but it was not assigned in any fuel
-    N20: Emission factor for Nitrous Oxide but it was not assigned in any fuel
-    FGA: Emission factor for Fluorinated gases but it was not assigned in any fuel
   fuels:
-    ETH: Ethanol fuel
-    CR1: Crude oil fuel
-    CR2: Crude oil fuel - processed
-    BIO: Biomass fuel
-    COA: Coal fuel
-    LFO: Light Fuel Oil fuel
-    GAS: Gas fuel
-    HFO: Heavy Fuel Oil fuel
-    SOL: Solar potential
-    WIN: Wind potential
-    URN: Uranium fuel
-    CHA: Charcoal fuel
-    WA1: Water withdrawal fuel
-    WA2: Water consumption fuel
-    EL1: Electricity from power plants
-    HE2: Heat from power plants
-    EL2: Electricity after transmission
-    FW3: Total Firewood demand (non-power sector)
-    HE3: Total Heat demand
-    EL3: Total Electricity demand
-    HF3: Total Heavy Fuel Oil demand (non-power sector)
-    LF3: Total Light Fuel Oil demand (non-power sector)
-    CH3: Total Charcoal demand (non-power sector)
-    GA3: Total Gas demand (non-power sector)
-    CO3: Total Coal demand (non-power sector)
-    BO3: Total Biofuel demand (non-power sector)
-    CR3: Total Crude Oil demand (for exports)
-    DEL: Electricity exports to non-African countries
-    DLG: LNG exports to non-African countries
+    'REN': Emission factor that was used to model the RET targets for each country
+    'CO2': Emission factor for CO2
+    'CH4': Emission factor for methane but it was not assigned in any fuel
+    'N20': Emission factor for Nitrous Oxide but it was not assigned in any fuel
+    'FGA': Emission factor for Fluorinated gases but it was not assigned in any fuel
+    'ETH': Ethanol fuel
+    'CR1': Crude oil fuel
+    'CR2': Crude oil fuel - processed
+    'BIO': Biomass fuel
+    'COA': Coal fuel
+    'LFO': Light Fuel Oil fuel
+    'GAS': Gas fuel
+    'HFO': Heavy Fuel Oil fuel
+    'SOL': Solar potential
+    'WIN': Wind potential
+    'URN': Uranium fuel
+    'CHA': Charcoal fuel
+    'WA1': Water withdrawal fuel
+    'WA2': Water consumption fuel
+    'EL1': Electricity from power plants
+    'HE2': Heat from power plants
+    'EL2': Electricity after transmission
+    'FW3': Total Firewood demand (non-power sector)
+    'HE3': Total Heat demand
+    'EL3': Total Electricity demand
+    'HF3': Total Heavy Fuel Oil demand (non-power sector)
+    'LF3': Total Light Fuel Oil demand (non-power sector)
+    'CH3': Total Charcoal demand (non-power sector)
+    'GA3': Total Gas demand (non-power sector)
+    'CO3': Total Coal demand (non-power sector)
+    'BO3': Total Biofuel demand (non-power sector)
+    'CR3': Total Crude Oil demand (for exports)
+    'DEL': Electricity exports to non-African countries
+    'DLG': LNG exports to non-African countries
   technologies:
-    CH: biomass CHP plant
-    SC: Superctritical coal
-    CV: conventional geothermal
-    GC: gas cycle
-    LS: large size hydro
-    MS: medium size hydro
-    SS: small size hydro
-    SA: stand alone
-    RC: LFO
-    CC: combined cycle
-    PW: pressurized water reactor (nuclear)
-    CN: CSP (without storage)
-    CS: CSP (with storage)
-    PU: PV(utility)
-    PR: PV(roof top)
-    PS: PV (with storage)
-    ON: onshore (wind)
-    OF: offshore (wind)
-  trade:
-    IM: imports
-    PR: production/extraction
-    EX: export
-  process:
-    TR: transmission
-    DI: distribution
+    'CH': biomass CHP plant
+    'SC': Superctritical coal
+    'CV': conventional geothermal
+    'GC': gas cycle
+    'LS': large size hydro
+    'MS': medium size hydro
+    'SS': small size hydro
+    'SA': stand alone
+    'RC': LFO
+    'CC': combined cycle
+    'PW': pressurized water reactor (nuclear)
+    'CN': CSP (without storage)
+    'CS': CSP (with storage)
+    'PU': PV(utility)
+    'PV': PV(roof top)
+    'PS': PV(with storage)
+    'ON': onshore (wind)
+    'OF': offshore (wind)
+    'IM': imports
+    'PR': production/extraction
+    'EX': export
+    'TR': transmission
+    'DI': distribution
   cooling:
-    00: No cooling type
-    01: AIR
-    02: MDT
-    03: NDT
-    04: OTF/OTS
+    '00': No cooling type
+    '01': AIR
+    '02': MDT
+    '03': NDT
+    '04': OTF/OTS
   age:
-    O: existing or historical plant
-    N: new plant
-    X: no distinction/not applicable
+    'O': existing or historical plant
+    'N': new plant
+    'X': no distinction/not applicable
   countries:
-    DZA: Algeria
-    AGO: Angola
-    BEN: Benin
-    BWA: Botswana
-    BFA: Burkina Faso
-    BDI: Burundi
-    CMR: Cameroon
-    CAF: Central African Republic
-    TCD: Chad
-    COD: Congo Democratic Republic
-    COG: Congo People Republic
-    CIV: Cote d'Ivoire
-    DJI: Djibouti
-    EGY: Egypt
-    GNQ: Equatorial Guinea
-    ERI: Eritrea
-    ETH: Ethiopia
-    GAB: Gabon
-    GMB: Gambia
-    GHA: Ghana
-    GIN: Guinea
-    GNB: Guinea-Bissau
-    KEN: Kenya
-    LSO: Lesotho
-    LBR: Liberia
-    LBY: Libya
-    MWI: Malawi
-    MLI: Mali
-    MRT: Mauritania
-    MAR: Morocco
-    MOZ: Mozambique
-    NAM: Namibia
-    NER: Niger
-    NGA: Nigeria
-    RWA: Rwanda
-    SEN: Senegal
-    SLE: Sierra Leone
-    SOM: Somalia
-    ZAF: South Africa
-    SDN: Sudan
-    SWZ: Swaziland
-    TZA: Tanzania
-    TGO: Togo
-    TUN: Tunisia
-    UGA: Uganda
-    ZMB: Zambia
-    ZWE: Zimbabwe
-    SSD: South Sudan
+    'AGO': Angola
+    'BDI': Burundi
+    'BEN': Benin
+    'BFA': Burkina Faso
+    'BWA': Botswana
+    'CAF': Central African Republic
+    'CIV': Cote d'Ivoire
+    'CMR': Cameroon
+    'COD': Congo Democratic Republic
+    'COG': Congo People Republic
+    'DJI': Djibouti
+    'DZA': Algeria
+    'EGY': Egypt
+    'ERI': Eritrea
+    'ETH': Ethiopia
+    'GAB': Gabon
+    'GHA': Ghana
+    'GIN': Guinea
+    'GMB': Gambia
+    'GNB': Guinea-Bissau
+    'GNQ': Equatorial Guinea
+    'KEN': Kenya
+    'LBR': Liberia
+    'LBY': Libya
+    'LSO': Lesotho
+    'MAR': Morocco
+    'MLI': Mali
+    'MOZ': Mozambique
+    'MRT': Mauritania
+    'MWI': Malawi
+    'NAM': Namibia
+    'NER': Niger
+    'NGA': Nigeria
+    'RWA': Rwanda
+    'SDN': Sudan
+    'SEN': Senegal
+    'SLE': Sierra Leone
+    'SOM': Somalia
+    'SSD': South Sudan
+    'SWZ': Swaziland
+    'TCD': Chad
+    'TGO': Togo
+    'TUN': Tunisia
+    'TZA': Tanzania
+    'UGA': Uganda
+    'ZAF': South Africa
+    'ZMB': Zambia
+    'ZWE': Zimbabwe
 schema:
   fuel_name:
   - name: countries
@@ -147,48 +144,3 @@ schema:
   - name: age
     valid: age
     position: (12, )
-  import_technologies:
-  - name: countries
-    valid: countries
-    position: (1, 3)
-  - name: fuels
-    valid: fuels
-    position: (4, 6)
-  - name: technology
-    valid: trade
-    position: (7, 8)
-  - name: ccs
-    valid: ['P']
-    position: (9, )
-  - name: cooling_type
-    valid: ['00']
-    position: (10, 11)
-  - name: age
-    valid: ['X']
-    position: (12, )
-  process_technology:
-  - name: countries
-    valid: countries
-    position: (1, 3)
-  - name: fuels
-    valid: fuels
-    position: (4, 6)
-  - name: technology
-    valid: process
-    position: (7, 8)
-  - name: ccs
-    valid: ['P']
-    position: (9, )
-  - name: cooling_type
-    valid: ['00']
-    position: (10, 11)
-  - name: age
-    valid: ['X']
-    position: (12, )
-  emission_commodities:
-  - name: countries
-    valid: countries
-    position: (1, 3)
-  - name: emission
-    valid: emissions
-    position: (4, 6)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from otoole.validate import compose_expression, create_schema, read_validation_config, validate_fuel_name
+from otoole.validate import compose_expression, create_schema, read_validation_config, validate
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,7 @@ from otoole.validate import compose_expression, create_schema, read_validation_c
     )
 def test_validate_fuel_code_true(name, expected):
 
-    actual = validate_fuel_name(name)
+    actual = validate("^(DZA|AGO)(ETH|CR1)", name)
     assert actual == expected
 
 
@@ -25,12 +25,12 @@ def test_compose_expression():
                'position': (1, 3)
                },
               {'name': 'fuels',
-               'valid': ['ETH', 'CO1'],
+               'valid': ['ETH', 'CR1'],
                'postion': (4, 6)
                }]
 
     actual = compose_expression(schema)
-    expected = "^(DZA|AGO)(ETH|CO1)"
+    expected = "^(DZA|AGO)(ETH|CR1)"
     assert actual == expected
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -39,9 +39,12 @@ def test_read_packaged_validation():
     actual = read_validation_config()
     expected = ['codes', 'schema']
     assert list(actual.keys()) == expected
-    expected_codes = ['emissions', 'fuels', 'technologies', 'trade', 'process',
-                      'cooling', 'age', 'countries']
+    expected_codes = ['fuels', 'technologies', 'cooling', 'age', 'countries']
     assert list(actual['codes'].keys()) == expected_codes
+    assert list(actual['codes']['technologies'].keys()) == [
+        'CH', 'SC', 'CV', 'GC', 'LS', 'MS', 'SS', 'SA', 'RC', 'CC', 'PW',
+        'CN', 'CS', 'PU', 'PV', 'PS', 'ON', 'OF', 'IM', 'PR', 'EX', 'TR', 'DI'
+    ]
 
 
 def test_create_schema():
@@ -60,3 +63,15 @@ def test_create_schema():
                   'position': (1, 3)}]
                 }
     assert actual == expected
+
+
+def test_create_schema_duplicate_raises():
+
+    schema = {
+        'schema': {'fuel_name': [{'name': 'countries',
+                                  'valid': ['DZA', 'DZA'],
+                                  'position': (1, 3)}]
+                   }
+               }
+    with pytest.raises(ValueError):
+        create_schema(schema)

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -37,7 +37,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # provided versions
     # (prefer local venv, since the miniconda folder is cached)
     conda config --add channels conda-forge
-    conda create -p ./.venv --yes python=${PYTHON_VERSION} pip virtualenv pandas xlrd pyyaml graphviz networkx pulp
+    conda create -p ./.venv --yes python=${PYTHON_VERSION} pip virtualenv pyyaml graphviz
     source activate ./.venv
 fi
 

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -37,7 +37,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # provided versions
     # (prefer local venv, since the miniconda folder is cached)
     conda config --add channels conda-forge
-    conda create -p ./.venv --yes python=${PYTHON_VERSION} pip virtualenv pyyaml graphviz
+    conda create -p ./.venv --yes python=${PYTHON_VERSION} pip virtualenv pyyaml graphviz datapackage pulp
     source activate ./.venv
 fi
 


### PR DESCRIPTION
Partial solution to #12 

- Validates the naming codes used in the `technology` and `fuel` tables in a Tabular Data Package against an internally specified validation config file

To do:
- [x] Enable user specification of a validation config
- [ ] Validate all entries where technology or fuel are used
- [ ] Expand validation to timeslices, season and all other relevant sets

Prints out the following for [v1.0a](https://github.com/OSeMOSYS/simplicity/archive/v0.1a0.zip) of the Simplicity model:
```
***Beginning validation***

***Checking TECHNOLOGY names***

29 invalid names:
    BACKSTOP1, BACKSTOP2, BIOMASSPRO, CHP, ETHPLANT, ELEC_IMPORT, GAS_EXTRACTION, GAS_IMPORT, GRID_EXP, HYD1, HYD2, IMPDSL, IMPFERT, IMPRAWSUG, LNDFORCOV, LNDRES, LNDSUGPL, LNDSUGPLIR, LNDSUGPLRF, NGCC, RIVER, RIVER_2, RIVWATAGR, SOLPV1, SOLPV2, SUGFACTORY, TD, TD2, WINDPOWER

***Checking FUEL names***

21 invalid names:
    BAGASSE, BIOMASS, DSL, ETH, FEL1, FEL2, FER, GAS, HEAT, LAND, LANDFOREST, LNDSUGCAN, MOLASSES, RAWSUG, RIVERWATER, SEC_EL, STOREDENERGY, SUGCAN, WATAGR, WATIN, WATOUT

***Checking graph structure***

4 'technology' nodes are isolated:
     BIOMASSPRO, CHP, ELEC_IMPORT, TD2

4 'fuel' nodes are isolated:
     BIOMASS, HEAT, STOREDENERGY, WATOUT

1 'emission' nodes are isolated:
     WATCON


```