### PR TITLE
Validate resources using multiple expressions

### DIFF
--- a/src/otoole/validate.yaml
+++ b/src/otoole/validate.yaml
@@ -64,6 +64,9 @@ codes:
     '02': MDT
     '03': NDT
     '04': OTF/OTS
+  tradelink:
+    'EL1EX': electricity trade link
+    'NG1EX': natural gas trade link
   age:
     'O': existing or historical plant
     'N': new plant
@@ -118,29 +121,44 @@ codes:
     'ZMB': Zambia
     'ZWE': Zimbabwe
 schema:
-  fuel_name:
-  - name: countries
-    valid: countries
-    position: (1, 3)
-  - name: fuels
-    valid: fuels
-    position: (4, 6)
-  technology_name:
-  - name: countries
-    valid: countries
-    position: (1, 3)
-  - name: fuels
-    valid: fuels
-    position: (4, 6)
-  - name: technology
-    valid: technologies
-    position: (7, 8)
-  - name: ccs
-    valid: ['P', 'C']
-    position: (9, )
-  - name: cooling_type
-    valid: cooling
-    position: (10, 11)
-  - name: age
-    valid: age
-    position: (12, )
+  FUEL:
+  - name: fuel_name
+    items:
+    - name: countries
+      valid: countries
+      position: (1, 3)
+    - name: fuels
+      valid: fuels
+      position: (4, 6)
+  TECHNOLOGY:
+  - name: technology_name
+    items:
+    - name: countries
+      valid: countries
+      position: (1, 3)
+    - name: fuels
+      valid: fuels
+      position: (4, 6)
+    - name: technology
+      valid: technologies
+      position: (7, 8)
+    - name: ccs
+      valid: ['P', 'C']
+      position: (9, )
+    - name: cooling_type
+      valid: cooling
+      position: (10, 11)
+    - name: age
+      valid: age
+      position: (12, )
+  - name: trade_link
+    items:
+    - name: countries
+      valid: countries
+      position: (1, 3)
+    - name: tradelink
+      valid: tradelink
+      position: (4, 8)
+    - name: countries
+      valid: countries
+      position: (9, 11)

--- a/src/otoole/visualise/res.py
+++ b/src/otoole/visualise/res.py
@@ -36,7 +36,8 @@ def extract_nodes(package_rows: List[List], node_type='technology',
     """
     nodes = [(x[0], {'type': node_type,
                      'fillcolor': color, 'shape': shape,
-                     'style': 'filled'}
+                     'style': 'filled',
+                     'label': x[0]}
               )
              for x in package_rows]
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,14 @@
 import pytest
 
-from otoole.validate import compose_expression, create_schema, read_validation_config, validate
+from yaml import load
+
+from otoole.validate import (
+    compose_expression,
+    compose_multi_expression,
+    create_schema,
+    read_validation_config,
+    validate
+)
 
 
 @pytest.mark.parametrize(
@@ -15,6 +23,21 @@ from otoole.validate import compose_expression, create_schema, read_validation_c
 def test_validate_fuel_code_true(name, expected):
 
     actual = validate("^(DZA|AGO)(ETH|CR1)", name)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [("DZAETH", True),
+     ("AGOCR1", True),
+     ("CO1AGO", True),
+     ("AGOETHETH", False),
+     ("   ETH", False),
+     ("DVA", False)]
+    )
+def test_validate_fuel_code_true_multi(name, expected):
+
+    actual = validate("^(DZA|AGO)(ETH|CR1)|^(CO1)(AGO)", name)
     assert actual == expected
 
 
@@ -34,12 +57,44 @@ def test_compose_expression():
     assert actual == expected
 
 
+def test_compose_multi_expression():
+    resource = load("""
+- name: technology_name
+  items:
+  - name: countries
+    valid:
+      - DZA
+      - AGO
+    position: (1, 3)
+  - name: fuels
+    valid:
+      - ETH
+      - CR1
+    position: (4, 6)
+- name: trade_link
+  items:
+  - name: countries
+    valid:
+      - DZA
+      - AGO
+    position: (1, 3)
+  - name: tradelink
+    valid:
+      - EL1EX
+      - NG1EX
+    position: (4, 8)
+      """)
+    actual = compose_multi_expression(resource)
+    expected = "^(DZA|AGO)(ETH|CR1)|^(DZA|AGO)(EL1EX|NG1EX)"
+    assert actual == expected
+
+
 def test_read_packaged_validation():
 
     actual = read_validation_config()
     expected = ['codes', 'schema']
     assert list(actual.keys()) == expected
-    expected_codes = ['fuels', 'technologies', 'cooling', 'age', 'countries']
+    expected_codes = ['fuels', 'technologies', 'cooling', 'tradelink', 'age', 'countries']
     assert list(actual['codes'].keys()) == expected_codes
     assert list(actual['codes']['technologies'].keys()) == [
         'CH', 'SC', 'CV', 'GC', 'LS', 'MS', 'SS', 'SA', 'RC', 'CC', 'PW',
@@ -51,16 +106,46 @@ def test_create_schema():
 
     schema = {
         'codes': {'countries': {'DZA': 'Algeria', 'AGO': 'Angola'}},
-        'schema': {'fuel_name': [{'name': 'countries',
-                                  'valid': 'countries',
-                                  'position': (1, 3)}]
+        'schema': {'FUEL': [{'items': [{'name': 'countries',
+                                        'valid': 'countries',
+                                        'position': (1, 3)}],
+                             'name': 'fuels'}]
                    }
                }
     actual = create_schema(schema)
-    expected = {'fuel_name':
-                [{'name': 'countries',
-                  'valid': ['DZA', 'AGO'],
-                  'position': (1, 3)}]
+    expected = {'FUEL': [{'items': [{'name': 'countries',
+                                     'valid': ['DZA', 'AGO'],
+                                     'position': (1, 3)}],
+                          'name': 'fuels'}]
+                }
+    assert actual == expected
+
+
+def test_create_schema_two_items():
+
+    schema = {
+        'codes': {'countries': {'DZA': 'Algeria', 'AGO': 'Angola'},
+                  'other_countries': {'ELC': 'Electricity'}},
+        'schema': {'FUEL': [{'items': [{'name': 'countries',
+                                        'valid': 'countries',
+                                        'position': (1, 3)}],
+                             'name': 'countries'},
+                            {'items': [{'name': 'other_countries',
+                                        'valid': 'other_countries',
+                                        'position': (1, 3)}],
+                             'name': 'other_countries'}]
+                   }
+               }
+    actual = create_schema(schema)
+    expected = {'FUEL': [{'items': [{'name': 'countries',
+                                     'valid': ['DZA', 'AGO'],
+                                     'position': (1, 3)}],
+                          'name': 'countries'},
+                         {'items': [{'name': 'other_countries',
+                                     'valid': ['ELC'],
+                                     'position': (1, 3)}],
+                          'name': 'other_countries'}
+                         ]
                 }
     assert actual == expected
 
@@ -68,9 +153,11 @@ def test_create_schema():
 def test_create_schema_duplicate_raises():
 
     schema = {
-        'schema': {'fuel_name': [{'name': 'countries',
-                                  'valid': ['DZA', 'DZA'],
-                                  'position': (1, 3)}]
+        'schema': {'FUEL': [{'items': [{'name': 'countries',
+                                        'valid': ['DZA', 'DZA'],
+                                        'position': (1, 3)}],
+                             'name': 'country'
+                             }]
                    }
                }
     with pytest.raises(ValueError):


### PR DESCRIPTION
Allows OSeMOSYS resources (e.g. sets such as TECHNOLOGY, FUEL, EMISSION) to be validated using multiple expressions defined in a YAML configuration file.