### PR TITLE
Fix for #36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 datapackage
 flatten_dict
-git+git://github.com/coin-or/pulp@a570ff9#egg=pulp
+git+git://github.com/coin-or/pulp@master#egg=pulp
 importlib_resources; python_version<'3.7'
 networkx
 pandas

--- a/src/otoole/preprocess/config.yaml
+++ b/src/otoole/preprocess/config.yaml
@@ -7,7 +7,7 @@ AnnualEmissionLimit:
     indices: [REGION,EMISSION,YEAR]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 AnnualExogenousEmission:
     indices: [REGION,EMISSION,YEAR]
     type: param
@@ -122,7 +122,7 @@ ModelPeriodEmissionLimit:
     indices: [REGION,EMISSION]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 ModelPeriodExogenousEmission:
     indices: [REGION,EMISSION]
     type: param
@@ -237,12 +237,12 @@ TotalAnnualMaxCapacity:
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 TotalAnnualMaxCapacityInvestment:
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 TotalAnnualMinCapacity:
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
@@ -262,7 +262,7 @@ TotalTechnologyAnnualActivityUpperLimit:
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 TotalTechnologyModelPeriodActivityLowerLimit:
     indices: [REGION,TECHNOLOGY]
     type: param
@@ -272,7 +272,7 @@ TotalTechnologyModelPeriodActivityUpperLimit:
     indices: [REGION,TECHNOLOGY]
     type: param
     dtype: float
-    default: 99999
+    default: -1
 TradeRoute:
     indices: [REGION,FUEL,YEAR]
     type: param

--- a/src/otoole/preprocess/create_datapackage.py
+++ b/src/otoole/preprocess/create_datapackage.py
@@ -64,7 +64,7 @@ def generate_package(path_to_package):
 
             descriptor['schema']['foreignKeys'] = foreign_keys
             descriptor['schema']['primaryKey'] = indices
-            descriptor['schema']['missingValues'] = [str(config[name]['default'])]
+            descriptor['schema']['missingValues'] = []
 
         new_resources.append(descriptor)
 

--- a/src/otoole/preprocess/datafile_to_datapackage.py
+++ b/src/otoole/preprocess/datafile_to_datapackage.py
@@ -16,6 +16,19 @@ from otoole.preprocess.longify_data import check_datatypes, check_set_datatype, 
 logger = logging.getLogger(__name__)
 
 
+def write_default_values(filepath):
+
+    config = read_packaged_file('config.yaml', 'otoole.preprocess')
+
+    default_values_path = os.path.join(filepath, 'data', 'default_values.csv')
+    with open(default_values_path, 'w') as csv_file:
+        csv_file.write('name,default_value\n')
+
+        for name, contents in config.items():
+            if contents['type'] == 'param':
+                csv_file.write('{},{}\n'.format(name, contents['default']))
+
+
 def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
     """Converts an OSeMOSYS datafile to a Tabular Data Package
 
@@ -37,6 +50,7 @@ def convert_file_to_package(path_to_datafile: str, path_to_datapackage: str):
     filepath = os.path.join(path_to_datapackage, 'datapackage.json')
     with open(filepath, 'w') as destination:
         destination.writelines(datapackage)
+    write_default_values(path_to_datapackage)
 
 
 def read_in_datafile(path_to_datafile: str, config: Dict) -> Amply:

--- a/src/otoole/preprocess/datapackage.json
+++ b/src/otoole/preprocess/datapackage.json
@@ -16,9 +16,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -51,9 +49,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -114,9 +110,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -177,9 +171,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -235,9 +227,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -285,9 +275,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -330,9 +318,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0.05"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -377,9 +363,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -440,9 +424,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -513,9 +495,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -577,9 +557,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -612,9 +590,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -675,9 +651,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -748,9 +722,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -827,9 +799,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -885,9 +855,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "TIMESLICE",
@@ -935,9 +903,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "TIMESLICE",
@@ -985,9 +951,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0.00137"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "DAILYTIMEBRACKET",
@@ -1040,9 +1004,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1108,9 +1070,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1179,9 +1139,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1242,9 +1200,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1290,9 +1246,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -1320,9 +1274,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1360,9 +1312,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -1405,9 +1355,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1479,9 +1427,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1534,9 +1480,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1592,9 +1536,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1647,9 +1589,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1715,9 +1655,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1786,9 +1724,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1844,9 +1780,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1884,9 +1818,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -1914,9 +1846,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -1969,9 +1899,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2037,9 +1965,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2108,9 +2034,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2156,9 +2080,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2176,9 +2098,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2206,9 +2126,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2261,9 +2179,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2319,9 +2235,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2374,9 +2288,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2442,9 +2354,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2503,9 +2413,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2550,9 +2458,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "7"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "SEASON",
@@ -2608,9 +2514,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "TIMESLICE",
@@ -2658,9 +2562,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "TIMESLICE",
@@ -2698,9 +2600,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2718,9 +2618,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2753,9 +2651,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2816,9 +2712,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2864,9 +2758,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2899,9 +2791,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -2947,9 +2837,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    ""
-                ]
+                "missingValues": []
             }
         },
         {
@@ -2977,9 +2865,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "1"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3032,9 +2918,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3090,9 +2974,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "99999"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3140,9 +3022,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3195,9 +3075,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3258,9 +3136,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",
@@ -3326,9 +3202,7 @@
                         "format": "default"
                     }
                 ],
-                "missingValues": [
-                    "0"
-                ],
+                "missingValues": [],
                 "foreignKeys": [
                     {
                         "fields": "REGION",

--- a/src/otoole/preprocess/datapackage.json
+++ b/src/otoole/preprocess/datapackage.json
@@ -2,6 +2,29 @@
     "profile": "tabular-data-package",
     "resources": [
         {
+            "path": "data/default_values.csv",
+            "profile": "tabular-data-resource",
+            "name": "default_values",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "default_value",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": []
+            }
+        },
+        {
             "path": "data/MODE_OF_OPERATION.csv",
             "profile": "tabular-data-resource",
             "name": "MODE_OF_OPERATION",

--- a/src/otoole/preprocess/longify_data.py
+++ b/src/otoole/preprocess/longify_data.py
@@ -1,3 +1,5 @@
+"""Read in a folder of irregular wide-format csv files and write them out as narrow csvs
+"""
 import logging
 import os
 import sys


### PR DESCRIPTION
Upon converting to a datapackage, otoole now writes the default values for parameters into the datapackage as `default_values.csv`.

Bug #36 was caused by the erroneous use of "missing values", which replaced all values that matched the list of missing values with `N/A`. These were then omitted when writing back out to the datafile.

This pull request removes the use of the missingvalues field, and instead stores the default values in a separate csv file in the datapackage.

