### PR TITLE
Read a dict of parameters from memory

### DIFF
--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -21,6 +21,13 @@ Convert a GNUMathProg datafile to a folder of CSV files::
 >>> converter = Context(read_strategy=reader, write_strategy=writer)
 >>> converter.convert('my_datafile.txt', 'folder_of_csv_files')
 
+Convert a GNUMathProg datafile to a folder of Tabular DataPackage::
+
+>>> reader = ReadDataFile()
+>>> writer = WriteDatapackage()
+>>> converter = Context(read_strategy=reader, write_strategy=writer)
+>>> converter.convert('my_datafile.txt', 'my_datapackage')
+
 """
 from __future__ import annotations
 

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -207,4 +207,4 @@ class ReadStrategy(Strategy):
 
     @abstractmethod
     def read(self, filepath: str) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:
-        pass
+        raise NotImplementedError()

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -1,3 +1,27 @@
+"""The ``input`` module allows you to access the conversion routines programmatically
+
+To use the routines, you need to instanciate a ``ReadStrategy`` and a ``WriteStrategy``
+relevant for the format of the input and output data.  You then pass these to a
+``Context``.
+
+Example
+-------
+Convert an in-memory dictionary of pandas DataFrames containing OSeMOSYS parameters
+to an Excel spreadsheet::
+
+>>> reader = ReadMemory(parameters)
+>>> writer = WriteExcel()
+>>> converter = Context(read_strategy=reader, write_strategy=writer)
+>>> converter.convert('.', 'osemosys_to_excel.xlsx')
+
+Convert a GNUMathProg datafile to a folder of CSV files::
+
+>>> reader = ReadDataFile()
+>>> writer = WriteCsv()
+>>> converter = Context(read_strategy=reader, write_strategy=writer)
+>>> converter.convert('my_datafile.txt', 'folder_of_csv_files')
+
+"""
 from __future__ import annotations
 
 import logging

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from amply import Amply
@@ -23,6 +23,21 @@ EXCEL_TO_CSV = {
 }
 
 CSV_TO_EXCEL = {v: k for k, v in EXCEL_TO_CSV.items()}
+
+
+class ReadMemory(ReadStrategy):
+    def __init__(self, parameters: Dict[str, Dict], user_config: Optional[Dict] = None):
+        super().__init__(user_config)
+        self._parameters = parameters
+
+    def read(
+        self, filepath: str = None,
+    ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:
+
+        config = self.config
+        default_values = self._read_default_values(config)
+
+        return self._parameters, default_values
 
 
 class ReadTabular(ReadStrategy):

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -26,7 +26,12 @@ CSV_TO_EXCEL = {v: k for k, v in EXCEL_TO_CSV.items()}
 
 
 class ReadMemory(ReadStrategy):
-    def __init__(self, parameters: Dict[str, Dict], user_config: Optional[Dict] = None):
+    """Read a dict of OSeMOSYS parameters from memory
+    """
+
+    def __init__(
+        self, parameters: Dict[str, pd.DataFrame], user_config: Optional[Dict] = None
+    ):
         super().__init__(user_config)
         self._parameters = parameters
 
@@ -40,7 +45,7 @@ class ReadMemory(ReadStrategy):
         return self._parameters, default_values
 
 
-class ReadTabular(ReadStrategy):
+class _ReadTabular(ReadStrategy):
     def _check_set(self, df, config_details, name):
 
         logger.info("Checking set %s", name)
@@ -87,7 +92,7 @@ class ReadTabular(ReadStrategy):
         return narrow[expected_headers]
 
 
-class ReadExcel(ReadTabular):
+class ReadExcel(_ReadTabular):
     """Read in an Excel spreadsheet in wide format to a dict of Pandas DataFrames
     """
 
@@ -131,7 +136,7 @@ class ReadExcel(ReadTabular):
         return input_data, default_values
 
 
-class ReadCsv(ReadTabular):
+class ReadCsv(_ReadTabular):
     """Read in a folder of CSV files"""
 
     def read(self, filepath) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -1,7 +1,33 @@
 import pandas as pd
 from amply import Amply
 
-from otoole.read_strategies import ReadDatafile
+from otoole.read_strategies import ReadDatafile, ReadMemory
+
+
+class TestReadMemoryStrategy:
+    def test_read_memory(self):
+
+        data = [
+            ["SIMPLICITY", "ETH", 2014, 1.0],
+            ["SIMPLICITY", "RAWSUG", 2014, 0.5],
+            ["SIMPLICITY", "ETH", 2015, 1.03],
+            ["SIMPLICITY", "RAWSUG", 2015, 0.51],
+        ]
+        df = pd.DataFrame(data=data, columns=["REGION", "FUEL", "YEAR", "VALUE"])
+        parameters = {"AccumulatedAnnualDemand": df}
+
+        actual, default_values = ReadMemory(parameters).read()
+
+        expected = {
+            "AccumulatedAnnualDemand": pd.DataFrame(
+                data=data, columns=["REGION", "FUEL", "YEAR", "VALUE"]
+            )
+        }
+
+        assert "AccumulatedAnnualDemand" in actual.keys()
+        pd.testing.assert_frame_equal(
+            actual["AccumulatedAnnualDemand"], expected["AccumulatedAnnualDemand"]
+        )
 
 
 class TestConfig:


### PR DESCRIPTION
Adds a `ReadMemory` class to the read strategies module to ease programmatic use of otoole when a user already has the OSeMOSYS parameters available in memory.