### PR TITLE
Updated otoole to run on OSeMOSYS V1.0.1

### DIFF
--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -95,20 +95,27 @@ def result_matrix(args):
     read_strategy = None
     write_strategy = None
 
+    config = None
+    if args.config:
+        _, ending = os.path.splitext(args.config)
+        with open(args.config, "r") as config_file:
+            config = _read_file(config_file, ending)
+        logger.info("Reading config from {}".format(args.config))
+
     if args.from_format == "cbc":
-        read_strategy = ReadCbc()
+        read_strategy = ReadCbc(user_config=config)
     elif args.from_format == "cplex":
-        read_strategy = ReadCplex()
+        read_strategy = ReadCplex(user_config=config)
     elif args.from_format == "gurobi":
-        read_strategy = ReadGurobi()
+        read_strategy = ReadGurobi(user_config=config)
 
     if args.to_format == "csv":
-        write_strategy = WriteCsv()
+        write_strategy = WriteCsv(user_config=config)
 
     if args.input_datapackage:
-        input_data, _ = ReadDatapackage().read(args.input_datapackage)
+        input_data, _ = ReadDatapackage(user_config=config).read(args.input_datapackage)
     elif args.input_datafile:
-        input_data, _ = ReadDatafile().read(args.input_datafile)
+        input_data, _ = ReadDatafile(user_config=config).read(args.input_datafile)
     else:
         input_data = {}
 
@@ -220,6 +227,7 @@ def get_parser():
         help="Input GNUMathProg datafile required for OSeMOSYS short or fast results",
         default=None,
     )
+    result_parser.add_argument("config", help="Path to config YAML file")
     result_parser.set_defaults(func=result_matrix)
 
     # Parser for conversion

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -249,6 +249,8 @@ class WriteStrategy(Strategy):
             if entity_type == "param":
                 default_value = default_values[name]
                 self._write_parameter(df, name, handle, default=default_value)
+            elif entity_type == "result":
+                self._write_parameter(df, name, handle, default=0)
             else:
                 self._write_set(df, name, handle)
 

--- a/src/otoole/preprocess/datapackage.json
+++ b/src/otoole/preprocess/datapackage.json
@@ -336,6 +336,41 @@
                         "format": "default"
                     },
                     {
+                        "name": "VALUE",
+                        "type": "number",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [""],
+                "foreignKeys": [
+                    {
+                        "fields": "REGION",
+                        "reference": {
+                            "resource": "REGION",
+                            "fields": "VALUE"
+                        }
+                    }
+                ],
+                "primaryKey": [
+                    "REGION"
+                ]
+            }
+        },
+        {
+            "path": "data/DiscountRateIdv.csv",
+            "profile": "tabular-data-resource",
+            "name": "DiscountRateIdv",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "REGION",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
                         "name": "TECHNOLOGY",
                         "type": "string",
                         "format": "default"

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -92,6 +92,11 @@ class ReadResults(ReadStrategy):
         output_data = input_data.copy()
 
         for param in parameters:
+
+            # skip empty sets
+            if "indices" not in self.user_config[param]:
+                continue
+
             indices = []
             for index in self.user_config[param]["indices"]:
                 indices.append(input_data[index]["VALUE"].to_list())  # get set values

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -33,6 +33,7 @@ class ReadResults(ReadStrategy):
         """
         if "input_data" in kwargs:
             input_data = kwargs["input_data"]
+            input_data = self._expand_defaults(input_data)
         else:
             input_data = None
 
@@ -70,6 +71,40 @@ class ReadResults(ReadStrategy):
                 LOGGER.debug("Error calculating %s: %s", name, str(ex))
 
         return results
+
+    def _expand_defaults(
+        self, input_data: Dict[str, pd.DataFrame]
+    ) -> Dict[str, pd.DataFrame]:
+        """Populates an empty parameter dataframe with its default value.
+
+        Arguments
+        ---------
+        input_data: Dict[str, pd.DataFrame]
+            Dictionary of input data
+
+        Returns
+        -------
+        output_data: dict
+            Updated input_data dictionary
+        """
+
+        parameters = [x for x in input_data if input_data[x].empty]
+        output_data = input_data.copy()
+
+        for param in parameters:
+            indices = []
+            for index in self.user_config[param]["indices"]:
+                indices.append(input_data[index]["VALUE"].to_list())  # get set values
+
+            index = pd.MultiIndex.from_product(
+                indices, names=self.user_config[param]["indices"]
+            )
+
+            df = pd.DataFrame(index=index)
+            df["VALUE"] = self.user_config[param]["default"]
+            output_data[param] = df
+
+        return output_data
 
 
 class ReadResultsCBC(ReadResults):
@@ -111,10 +146,11 @@ class ReadResultsCBC(ReadResults):
         not_found = []
 
         for name, details in sorted(self.results_config.items()):
-            df = data[data["Variable"] == name]
+            df_cbc = data[data["Variable"] == name]
 
-            if not df.empty:
+            if not df_cbc.empty:
 
+                df = df_cbc.copy()  # setting with copy warning
                 LOGGER.debug("Extracting results for %s", name)
                 indices = details["indices"]  # typing: List
 

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -191,7 +191,13 @@ class WriteCsv(WriteStrategy):
         self._write_out_dataframe(self.filepath, set_name, df, index=False)
 
     def _footer(self, handle: TextIO):
-        pass
+        # writes out default_values.csv
+        if self.default_values:
+            df = pd.DataFrame().from_dict(
+                self.default_values, orient="index", columns=["default_value"]
+            )
+            df = df.reset_index().rename({"index": "name"}, axis=1)
+            self._write_out_dataframe(self.filepath, "default_values", df, index=False)
 
 
 class WriteDatapackage(WriteStrategy):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,10 +59,27 @@ def annual_technology_emissions_by_mode():
 @fixture
 def discount_rate():
     df = pd.DataFrame(
-        data=[["SIMPLICITY", "GAS_EXTRACTION", 0.05]],
+        data=[["SIMPLICITY", 0.05]],
+        columns=["REGION", "VALUE"],
+    ).set_index(["REGION"])
+    return df
+
+
+@fixture
+def discount_rate_idv():
+    df = pd.DataFrame(
+        data=[["SIMPLICITY", "GAS_EXTRACTION", 0.05], ["SIMPLICITY", "DUMMY", 0.05]],
         columns=["REGION", "TECHNOLOGY", "VALUE"],
     ).set_index(["REGION", "TECHNOLOGY"])
+    return df
 
+
+@fixture
+def discount_rate_storage():
+    df = pd.DataFrame(
+        data=[["SIMPLICITY", "DAM", 0.05]],
+        columns=["REGION", "STORAGE", "VALUE"],
+    ).set_index(["REGION", "STORAGE"])
     return df
 
 

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -80,6 +80,11 @@ DepreciationMethod:
     dtype: float
     default: 1
 DiscountRate:
+    indices: [REGION]
+    type: param
+    dtype: float
+    default: 0.05
+DiscountRateIdv:
     indices: [REGION,TECHNOLOGY]
     type: param
     dtype: float
@@ -423,6 +428,36 @@ SalvageValue:
     default: 0
     calculated: False
 SalvageValueStorage:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelDayTypeFinish:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelDayTypeStart:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelSeasonStart:
+    indices: [REGION, STORAGE, SEASON, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearStart:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearFinish:
     indices: [REGION, STORAGE, YEAR]
     type: result
     dtype: float

--- a/tests/fixtures/config_r.yaml
+++ b/tests/fixtures/config_r.yaml
@@ -130,6 +130,36 @@ SalvageValueStorage:
     dtype: float
     default: 0
     calculated: False
+StorageLevelDayTypeFinish:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelDayTypeStart:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelSeasonStart:
+    indices: [REGION, STORAGE, SEASON, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearStart:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearFinish:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
 TotalAnnualTechnologyActivityByMode:
     indices: [REGION, TECHNOLOGY, MODE_OF_OPERATION, YEAR]
     type: result

--- a/tests/results/test_results.py
+++ b/tests/results/test_results.py
@@ -1,0 +1,100 @@
+import os
+from typing import Dict
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from pytest import fixture
+
+from otoole.results.results import ReadResults
+from otoole.utils import _read_file
+
+
+@fixture
+def user_config() -> Dict:
+    """Reads in an example user config
+
+    Read in an example user config file which can be passed into all
+    Read and Write strategies for testing
+
+    Returns
+    -------
+    Dict
+    """
+    file_path = os.path.join("tests", "fixtures", "config.yaml")
+    with open(file_path, "r") as config_file:
+        config = _read_file(config_file, ".yaml")  # typing: Dict
+
+    file_path = os.path.join("tests", "fixtures", "config_r.yaml")
+    with open(file_path, "r") as config_file:
+        results = _read_file(config_file, ".yaml")  # typing: Dict
+
+    config.update(results)
+
+    return config
+
+
+@fixture
+def input_data():
+    """To test that data will not be overwritten"""
+
+    capex = pd.DataFrame(
+        [
+            ["SIMPLICITY", "NGCC", 2014, 1000],
+            ["SIMPLICITY", "NGCC", 2015, 900],
+            ["SIMPLICITY", "NGCC", 2016, 800],
+            ["SIMPLICITY", "HYD1", 2014, 2000],
+            ["SIMPLICITY", "HYD1", 2015, 1500],
+            ["SIMPLICITY", "HYD1", 2016, 1000],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+    discount_rate = pd.DataFrame(columns=["VALUE"])
+
+    discount_rate_idv = pd.DataFrame(columns=["VALUE"])
+
+    technology = pd.DataFrame(["NGCC", "HYD1"], columns=["VALUE"])
+    year = pd.DataFrame([2014, 2015, 2016], columns=["VALUE"])
+    region = pd.DataFrame(["SIMPLICITY"], columns=["VALUE"])
+
+    data = {
+        "CapitalCost": capex,
+        "DiscountRate": discount_rate,
+        "DiscountRateIdv": discount_rate_idv,
+        "TECHNOLOGY": technology,
+        "YEAR": year,
+        "REGION": region,
+    }
+
+    return data
+
+
+class DummyReadResults(ReadResults):
+    def get_results_from_file(self, filepath, input_data):
+        raise NotImplementedError()
+
+
+class TestReadResults:
+    def test_do_not_expand(self, input_data, user_config):
+        results = DummyReadResults(user_config=user_config)
+        expected = input_data["CapitalCost"]
+        actual = results._expand_defaults(input_data)["CapitalCost"]
+        assert_frame_equal(actual, expected)
+
+    def test_single_index(self, input_data, user_config):
+        index = pd.MultiIndex.from_product([["SIMPLICITY"]], names=["REGION"])
+        expected = pd.DataFrame(index=index)
+        expected["VALUE"] = 0.05
+        results = DummyReadResults(user_config=user_config)
+        actual = results._expand_defaults(input_data)["DiscountRate"]
+        assert_frame_equal(actual, expected)
+
+    def test_multi_index(self, input_data, user_config):
+        index = pd.MultiIndex.from_product(
+            [["SIMPLICITY"], ["NGCC", "HYD1"]], names=["REGION", "TECHNOLOGY"]
+        )
+        expected = pd.DataFrame(index=index)
+        expected["VALUE"] = 0.05
+        results = DummyReadResults(user_config=user_config)
+        actual = results._expand_defaults(input_data)["DiscountRateIdv"]
+        assert_frame_equal(actual, expected)

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -2,7 +2,13 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 from pytest import fixture, raises
 
-from otoole.results.result_package import ResultsPackage, capital_recovery_factor
+from otoole.results.result_package import (
+    ResultsPackage,
+    capital_recovery_factor,
+    discount_factor,
+    discount_factor_storage,
+    pv_annuity,
+)
 
 
 @fixture
@@ -616,35 +622,222 @@ class TestComputeTotalAnnualCapacity:
 
 
 class TestCapitalRecoveryFactor:
-    def test_crf(self, discount_rate):
+    def test_crf(self, region, discount_rate_idv, operational_life):
 
-        regions = ["SIMPLICITY"]
-        technologies = ["GAS_EXTRACTION"]
-        years = [2010, 2011, 2012, 2013, 2014, 2015]
-        actual = capital_recovery_factor(regions, technologies, years, discount_rate)
+        technologies = ["GAS_EXTRACTION", "DUMMY"]
+        regions = region["VALUE"].to_list()
+        actual = capital_recovery_factor(
+            regions, technologies, discount_rate_idv, operational_life
+        )
 
         expected = pd.DataFrame(
             data=[
-                ["SIMPLICITY", "GAS_EXTRACTION", 2010, 1.0],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2011, 1.05],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2012, 1.1025],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2013, 1.1576250000000001],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.2155062500000002],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2015, 1.2762815625000004],
+                ["SIMPLICITY", "GAS_EXTRACTION", 0.512195121],
+                ["SIMPLICITY", "DUMMY", 0.349722442],
             ],
-            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
-        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+            columns=["REGION", "TECHNOLOGY", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY"])
 
         assert_frame_equal(actual, expected)
 
-    def test_crf_null(self, discount_rate):
+    def test_crf_null(self, discount_rate_idv, operational_life):
 
-        actual = capital_recovery_factor([], [], [], discount_rate)
+        actual = capital_recovery_factor([], [], discount_rate_idv, operational_life)
 
         expected = pd.DataFrame(
             data=[],
-            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
-        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+            columns=["REGION", "TECHNOLOGY", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestPvAnnuity:
+    def test_pva(self, region, discount_rate, operational_life):
+
+        technologies = ["GAS_EXTRACTION", "DUMMY"]
+        regions = region["VALUE"].to_list()
+        actual = pv_annuity(regions, technologies, discount_rate, operational_life)
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "GAS_EXTRACTION", 1.952380952],
+                ["SIMPLICITY", "DUMMY", 2.859410430],
+            ],
+            columns=["REGION", "TECHNOLOGY", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_pva_null(self, discount_rate):
+
+        actual = pv_annuity([], [], discount_rate, operational_life)
+
+        expected = pd.DataFrame(
+            data=[],
+            columns=["REGION", "TECHNOLOGY", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestDiscountFactor:
+    def test_df_start(self, region, year, discount_rate):
+
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor(regions, years, discount_rate, 0.0)
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", 2014, 1],
+                ["SIMPLICITY", 2015, 1.05],
+                ["SIMPLICITY", 2016, 1.1025],
+                ["SIMPLICITY", 2017, 1.157625],
+                ["SIMPLICITY", 2018, 1.21550625],
+                ["SIMPLICITY", 2019, 1.276281562],
+                ["SIMPLICITY", 2020, 1.340095640],
+            ],
+            columns=["REGION", "YEAR", "VALUE"],
+        ).set_index(["REGION", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_df_mid(self, region, year, discount_rate):
+
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor(regions, years, discount_rate, 0.5)
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", 2014, 1.024695076],
+                ["SIMPLICITY", 2015, 1.075929830],
+                ["SIMPLICITY", 2016, 1.129726321],
+                ["SIMPLICITY", 2017, 1.186212638],
+                ["SIMPLICITY", 2018, 1.245523269],
+                ["SIMPLICITY", 2019, 1.307799433],
+                ["SIMPLICITY", 2020, 1.373189405],
+            ],
+            columns=["REGION", "YEAR", "VALUE"],
+        ).set_index(["REGION", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_df_end(self, region, year, discount_rate):
+
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor(regions, years, discount_rate, 1.0)
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", 2014, 1.05],
+                ["SIMPLICITY", 2015, 1.1025],
+                ["SIMPLICITY", 2016, 1.157625],
+                ["SIMPLICITY", 2017, 1.21550625],
+                ["SIMPLICITY", 2018, 1.276281562],
+                ["SIMPLICITY", 2019, 1.340095640],
+                ["SIMPLICITY", 2020, 1.407100422],
+            ],
+            columns=["REGION", "YEAR", "VALUE"],
+        ).set_index(["REGION", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_df_null(self, discount_rate):
+
+        actual = discount_factor([], [], discount_rate, 0.0)
+
+        expected = pd.DataFrame(
+            data=[],
+            columns=["REGION", "YEAR", "VALUE"],
+        ).set_index(["REGION", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestDiscountFactorStorage:
+    def test_dfs_start(self, region, year, discount_rate_storage):
+
+        storages = ["DAM"]
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor_storage(
+            regions, storages, years, discount_rate_storage, 0.0
+        )
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DAM", 2014, 1],
+                ["SIMPLICITY", "DAM", 2015, 1.05],
+                ["SIMPLICITY", "DAM", 2016, 1.1025],
+                ["SIMPLICITY", "DAM", 2017, 1.157625],
+                ["SIMPLICITY", "DAM", 2018, 1.21550625],
+                ["SIMPLICITY", "DAM", 2019, 1.276281562],
+                ["SIMPLICITY", "DAM", 2020, 1.340095640],
+            ],
+            columns=["REGION", "STORAGE", "YEAR", "VALUE"],
+        ).set_index(["REGION", "STORAGE", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_dfs_mid(self, region, year, discount_rate_storage):
+
+        storages = ["DAM"]
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor_storage(
+            regions, storages, years, discount_rate_storage, 0.5
+        )
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DAM", 2014, 1.024695076],
+                ["SIMPLICITY", "DAM", 2015, 1.075929830],
+                ["SIMPLICITY", "DAM", 2016, 1.129726321],
+                ["SIMPLICITY", "DAM", 2017, 1.186212638],
+                ["SIMPLICITY", "DAM", 2018, 1.245523269],
+                ["SIMPLICITY", "DAM", 2019, 1.307799433],
+                ["SIMPLICITY", "DAM", 2020, 1.373189405],
+            ],
+            columns=["REGION", "STORAGE", "YEAR", "VALUE"],
+        ).set_index(["REGION", "STORAGE", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_dfs_end(self, region, year, discount_rate_storage):
+
+        storages = ["DAM"]
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+        actual = discount_factor_storage(
+            regions, storages, years, discount_rate_storage, 1.0
+        )
+
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DAM", 2014, 1.05],
+                ["SIMPLICITY", "DAM", 2015, 1.1025],
+                ["SIMPLICITY", "DAM", 2016, 1.157625],
+                ["SIMPLICITY", "DAM", 2017, 1.21550625],
+                ["SIMPLICITY", "DAM", 2018, 1.276281562],
+                ["SIMPLICITY", "DAM", 2019, 1.340095640],
+                ["SIMPLICITY", "DAM", 2020, 1.407100422],
+            ],
+            columns=["REGION", "STORAGE", "YEAR", "VALUE"],
+        ).set_index(["REGION", "STORAGE", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_df_null(self, discount_rate_storage):
+
+        actual = discount_factor_storage([], [], [], discount_rate_storage, 0.0)
+
+        expected = pd.DataFrame(
+            data=[],
+            columns=["REGION", "STORAGE", "YEAR", "VALUE"],
+        ).set_index(["REGION", "STORAGE", "YEAR"])
 
         assert_frame_equal(actual, expected)
 


### PR DESCRIPTION
In this PR I have:
- Updated otoole to follow [OSeMOSYS V1.0.1](https://github.com/OSeMOSYS/OSeMOSYS_GNU_MathProg/releases/tag/v1.0.1). Of note, this includes:
  -  Changing DiscountRate to be defined only over Region 
  - Adding the parameter DiscountRateIdv to otoole's CSV inputs
  - Adding/Updating calculations for DiscountFactor, DiscountFactorStorage, PvAnnuity and CapitalRecoveryFactor. This includes updating calculations that rely on these parameters
  - Adding calculations for the storage results of StorageLevelDayTypeFinish, StorageLevelDayTypeStart, StorageLevelSeasonStart, StorageLevelYearStart, StorageLevelYearFinish
- During result calculations, default value dataframes are populated prior to the actual calculation. This avoids situations where parameters (such as DiscountRate) will have empty dataframes if values arn't entered by the user, causing resulting calculations will break and not print results. 
- Added tests for new calculations/functionality
- Added writing out `default_values.csv` functionality to the WriteCSV class.

This PR addresses issues #109, #115  