### PR TITLE
Long parameter names cause an error in writing to an Excel spreadsheet

### DIFF
--- a/src/otoole/exceptions.py
+++ b/src/otoole/exceptions.py
@@ -39,3 +39,33 @@ class OtooleRelationError(OtooleException):
         self.resource = resource
         self.foreign_resource = foreign_resource
         self.message = message
+
+
+class OtooleExcelNameLengthError(OtooleException):
+    """Invalid tab name for writing to Excel."""
+
+    def __init__(
+        self,
+        name: str,
+        message: str = "Parameter name must be less then 31 characters when writing to Excel",
+    ) -> None:
+        self.name = name
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.name} -> {self.message}"
+
+
+class OtooleExcelNameMismatchError(OtooleException):
+    """Name mismatch between config and excel tabs."""
+
+    def __init__(
+        self, excel_name: str, message: str = "Excel tab name not found in config file"
+    ) -> None:
+        self.excel_name = excel_name
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.excel_name} -> {self.message}"

--- a/src/otoole/exceptions.py
+++ b/src/otoole/exceptions.py
@@ -47,7 +47,7 @@ class OtooleExcelNameLengthError(OtooleException):
     def __init__(
         self,
         name: str,
-        message: str = "Parameter name must be less then 31 characters when writing to Excel",
+        message: str = "Parameter name must be less than 31 characters when writing to Excel",
     ) -> None:
         self.name = name
         self.message = message

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -9,26 +9,9 @@ from pandas_datapackage_reader import read_datapackage
 
 from otoole.input import ReadStrategy
 from otoole.preprocess.longify_data import check_datatypes, check_set_datatype
-from otoole.utils import read_datapackage_schema_into_config
+from otoole.utils import create_name_mappings, read_datapackage_schema_into_config
 
 logger = logging.getLogger(__name__)
-
-
-EXCEL_TO_CSV = {
-    "TotalAnnualMaxCapacityInvestmen": "TotalAnnualMaxCapacityInvestment",
-    "TotalAnnualMinCapacityInvestmen": "TotalAnnualMinCapacityInvestment",
-    "TotalTechnologyAnnualActivityLo": "TotalTechnologyAnnualActivityLowerLimit",
-    "TotalTechnologyAnnualActivityUp": "TotalTechnologyAnnualActivityUpperLimit",
-    "TotalTechnologyModelPeriodActLo": "TotalTechnologyModelPeriodActivityLowerLimit",
-    "TotalTechnologyModelPeriodActUp": "TotalTechnologyModelPeriodActivityUpperLimit",
-    "TechWithCapacityNeededToMeetPea": "TechWithCapacityNeededToMeetPeakTS",
-    "TechnologyActivityByModeUpperLi": "TechnologyActivityByModeUpperLimit",
-    "TechnologyActivityByModeLowerLi": "TechnologyActivityByModeLowerLimit",
-    "TechnologyActivityIncreaseByMod": "TechnologyActivityIncreaseByModeLimit",
-    "TechnologyActivityDecreaseByMod": "TechnologyActivityDecreaseByModeLimit",
-}
-
-CSV_TO_EXCEL = {v: k for k, v in EXCEL_TO_CSV.items()}
 
 
 class ReadMemory(ReadStrategy):
@@ -113,6 +96,7 @@ class ReadExcel(_ReadTabular):
 
         config = self.user_config
         default_values = self._read_default_values(config)
+        excel_to_csv = create_name_mappings(config, map_full_to_short=False)
 
         xl = pd.ExcelFile(filepath, engine="openpyxl")
 
@@ -121,7 +105,7 @@ class ReadExcel(_ReadTabular):
         for name in xl.sheet_names:
 
             try:
-                mod_name = EXCEL_TO_CSV[name]
+                mod_name = excel_to_csv[name]
             except KeyError:
                 mod_name = name
 

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -143,10 +143,10 @@ class ReadExcel(_ReadTabular):
             If the sheet name is not found in the config files parameter or
             'short_name' parameter
         """
-        config = self.user_config
-        csv_to_excel = create_name_mappings(config)
+        user_config = self.user_config
+        csv_to_excel = create_name_mappings(user_config)
         config_param_names = []
-        for name in config:
+        for name in user_config:
             try:
                 config_param_names.append(csv_to_excel[name])
             except KeyError:

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -7,6 +7,7 @@ from amply import Amply
 from flatten_dict import flatten
 from pandas_datapackage_reader import read_datapackage
 
+from otoole.exceptions import OtooleExcelNameMismatchError
 from otoole.input import ReadStrategy
 from otoole.preprocess.longify_data import check_datatypes, check_set_datatype
 from otoole.utils import create_name_mappings, read_datapackage_schema_into_config
@@ -100,6 +101,8 @@ class ReadExcel(_ReadTabular):
 
         xl = pd.ExcelFile(filepath, engine="openpyxl")
 
+        self._check_input_sheet_names(xl.sheet_names)
+
         input_data = {}
 
         for name in xl.sheet_names:
@@ -125,6 +128,33 @@ class ReadExcel(_ReadTabular):
         input_data = self._check_index(input_data)
 
         return input_data, default_values
+
+    def _check_input_sheet_names(self, sheet_names: List[str]) -> None:
+        """Checks that excel sheet names are in the config file.
+
+        Arguments:
+        ---------
+        sheet_names: list[str]
+            Sheet names from the excel file
+
+        Raises:
+        -------
+        OtooleExcelNameMismatchError
+            If the sheet name is not found in the config files parameter or
+            'short_name' parameter
+        """
+        config = self.user_config
+        csv_to_excel = create_name_mappings(config)
+        config_param_names = []
+        for name in config:
+            try:
+                config_param_names.append(csv_to_excel[name])
+            except KeyError:
+                config_param_names.append(name)
+
+        for sheet_name in sheet_names:
+            if sheet_name not in config_param_names:
+                raise OtooleExcelNameMismatchError(excel_name=sheet_name)
 
 
 class ReadCsv(_ReadTabular):

--- a/src/otoole/utils.py
+++ b/src/otoole/utils.py
@@ -128,6 +128,11 @@ def create_name_mappings(
     for name, params in config.items():
         try:
             csv_to_excel[name] = params["short_name"]
+            if len(csv_to_excel[name]) > 31:
+                logger.warning(
+                    f"The short_name, {csv_to_excel[name]} for parameter {name} "
+                    "is longer then 31 characters will not be read from excel."
+                )
         except KeyError:
             if len(name) > 31:
                 logger.warning(
@@ -139,4 +144,5 @@ def create_name_mappings(
     if map_full_to_short:
         return csv_to_excel
     else:
-        return {v: k for k, v in csv_to_excel.items()}
+        excel_to_csv = {v: k for k, v in csv_to_excel.items()}
+        return excel_to_csv

--- a/src/otoole/utils.py
+++ b/src/otoole/utils.py
@@ -105,10 +105,7 @@ def extract_config(
 def create_name_mappings(
     config: Dict[str, Dict[str, Union[str, List]]], map_full_to_short: bool = True
 ) -> Dict:
-    """Creates name mapping for full name to short name.
-
-    Also warns the user if the name is longer then 31 characters and does
-    not have a short name.
+    """Creates name mapping between full name and short name.
 
     Arguments
     ---------
@@ -128,17 +125,9 @@ def create_name_mappings(
     for name, params in config.items():
         try:
             csv_to_excel[name] = params["short_name"]
-            if len(csv_to_excel[name]) > 31:
-                logger.warning(
-                    f"The short_name, {csv_to_excel[name]} for parameter {name} "
-                    "is longer then 31 characters will not be read from excel."
-                )
         except KeyError:
             if len(name) > 31:
-                logger.warning(
-                    f"{name} is longer then 31 characters and does not have a "
-                    "'short_name' in the configuration file"
-                )
+                logger.info(f"{name} does not have a 'short_name'")
             continue
 
     if map_full_to_short:

--- a/src/otoole/utils.py
+++ b/src/otoole/utils.py
@@ -133,5 +133,4 @@ def create_name_mappings(
     if map_full_to_short:
         return csv_to_excel
     else:
-        excel_to_csv = {v: k for k, v in csv_to_excel.items()}
-        return excel_to_csv
+        return {v: k for k, v in csv_to_excel.items()}

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -5,6 +5,7 @@ from typing import TextIO
 import pandas as pd
 from frictionless import Package, Resource
 
+from otoole.exceptions import OtooleExcelNameLengthError
 from otoole.input import WriteStrategy
 from otoole.preprocess.create_datapackage import generate_package
 
@@ -76,6 +77,10 @@ class WriteExcel(WriteStrategy):
             name = self.user_config[parameter_name]["short_name"]
         except KeyError:
             name = parameter_name
+
+        if len(name) > 31:
+            raise OtooleExcelNameLengthError(name=name)
+
         df = self._form_parameter(df, parameter_name, default)
         if not df.empty:
             df.to_excel(handle, sheet_name=name, merge_cells=False, index=True)

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -7,7 +7,6 @@ from frictionless import Package, Resource
 
 from otoole.input import WriteStrategy
 from otoole.preprocess.create_datapackage import generate_package
-from otoole.read_strategies import CSV_TO_EXCEL
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +73,7 @@ class WriteExcel(WriteStrategy):
         default: float,
     ):
         try:
-            name = CSV_TO_EXCEL[parameter_name]
+            name = self.user_config[parameter_name]["short_name"]
         except KeyError:
             name = parameter_name
         df = self._form_parameter(df, parameter_name, default)

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -249,6 +249,7 @@ TotalAnnualMaxCapacity:
     dtype: float
     default: -1
 TotalAnnualMaxCapacityInvestment:
+    short_name: TotalAnnualMaxCapacityInvestmen
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
@@ -259,26 +260,31 @@ TotalAnnualMinCapacity:
     dtype: float
     default: 0
 TotalAnnualMinCapacityInvestment:
+    short_name: TotalAnnualMinCapacityInvestmen
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
     default: 0
 TotalTechnologyAnnualActivityLowerLimit:
+    short_name: TotalTechnologyAnnualActivityLo
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
     default: 0
 TotalTechnologyAnnualActivityUpperLimit:
+    short_name: TotalTechnologyAnnualActivityUp
     indices: [REGION,TECHNOLOGY,YEAR]
     type: param
     dtype: float
     default: -1
 TotalTechnologyModelPeriodActivityLowerLimit:
+    short_name: TotalTechnologyModelPeriodActLo
     indices: [REGION,TECHNOLOGY]
     type: param
     dtype: float
     default: 0
 TotalTechnologyModelPeriodActivityUpperLimit:
+    short_name: TotalTechnologyModelPeriodActUp
     indices: [REGION,TECHNOLOGY]
     type: param
     dtype: float

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from otoole.utils import extract_config, read_packaged_file
+from otoole.utils import create_name_mappings, extract_config, read_packaged_file
 
 
 class TestDataPackageSchema:
@@ -16,4 +16,30 @@ class TestDataPackageSchema:
         actual = extract_config(schema, mock)
 
         expected = read_packaged_file("config.yaml", "otoole.preprocess")
+        assert actual == expected
+
+
+class TestCreateNameMappings:
+    def test_create_name_mappings(self, user_config):
+        expected = {
+            "TotalAnnualMaxCapacityInvestment": "TotalAnnualMaxCapacityInvestmen",
+            "TotalAnnualMinCapacityInvestment": "TotalAnnualMinCapacityInvestmen",
+            "TotalTechnologyAnnualActivityLowerLimit": "TotalTechnologyAnnualActivityLo",
+            "TotalTechnologyAnnualActivityUpperLimit": "TotalTechnologyAnnualActivityUp",
+            "TotalTechnologyModelPeriodActivityLowerLimit": "TotalTechnologyModelPeriodActLo",
+            "TotalTechnologyModelPeriodActivityUpperLimit": "TotalTechnologyModelPeriodActUp",
+        }
+        actual = create_name_mappings(user_config)
+        assert actual == expected
+
+    def test_create_name_mappings_reversed(self, user_config):
+        expected = {
+            "TotalAnnualMaxCapacityInvestmen": "TotalAnnualMaxCapacityInvestment",
+            "TotalAnnualMinCapacityInvestmen": "TotalAnnualMinCapacityInvestment",
+            "TotalTechnologyAnnualActivityLo": "TotalTechnologyAnnualActivityLowerLimit",
+            "TotalTechnologyAnnualActivityUp": "TotalTechnologyAnnualActivityUpperLimit",
+            "TotalTechnologyModelPeriodActLo": "TotalTechnologyModelPeriodActivityLowerLimit",
+            "TotalTechnologyModelPeriodActUp": "TotalTechnologyModelPeriodActivityUpperLimit",
+        }
+        actual = create_name_mappings(user_config, map_full_to_short=False)
         assert actual == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,40 @@
+from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
+from otoole.exceptions import OtooleExcelNameLengthError, OtooleExcelNameMismatchError
+from otoole.read_strategies import ReadExcel
 from otoole.utils import create_name_mappings, extract_config, read_packaged_file
+from otoole.write_strategies import WriteExcel
+
+
+@pytest.fixture()
+def user_config_long_param_name():
+    config = {}
+    config["REGION"] = {"dtype": "str", "type": "set"}
+    config["ParameterNameLongerThanThirtyOneChars"] = {
+        "indices": ["REGION"],
+        "type": "param",
+        "dtype": "float",
+        "default": 0.05,
+    }
+    return config
+
+
+@pytest.fixture()
+def user_config_long_short_name():
+    config = {}
+    config["REGION"] = {"dtype": "str", "type": "set"}
+    config["ParameterNameLongerThanThirtyOneChars"] = {
+        "short_name": "ShortNameAlsoLongerThanThirtyOneChars",
+        "indices": ["REGION"],
+        "type": "param",
+        "dtype": "float",
+        "default": 0.05,
+    }
+    return config
 
 
 class TestDataPackageSchema:
@@ -43,3 +75,33 @@ class TestCreateNameMappings:
         }
         actual = create_name_mappings(user_config, map_full_to_short=False)
         assert actual == expected
+
+
+def test_excel_name_mismatch_error(user_config):
+    read_excel = ReadExcel(user_config=user_config)
+    sheet_names = ["AccumulatedAnnualDemand", "MismatchSheet"]
+    with pytest.raises(OtooleExcelNameMismatchError):
+        read_excel._check_input_sheet_names(sheet_names=sheet_names)
+
+
+user_config_name_errors = ["user_config_long_param_name", "user_config_long_short_name"]
+
+
+@pytest.mark.parametrize(
+    "user_config_simple",
+    user_config_name_errors,
+    ids=["full_name_error", "short_name_error"],
+)
+def test_excel_name_length_error(user_config_simple, request):
+    user_config = request.getfixturevalue(user_config_simple)
+    write_excel = WriteExcel(user_config=user_config)
+    temp_excel = NamedTemporaryFile(suffix=".xlsx")
+    handle = pd.ExcelWriter(temp_excel.name)
+
+    with pytest.raises(OtooleExcelNameLengthError):
+        write_excel._write_parameter(
+            df=pd.DataFrame(),
+            parameter_name="ParameterNameLongerThanThirtyOneChars",
+            handle=pd.ExcelWriter(handle),
+            default=0,
+        )


### PR DESCRIPTION
**OVERVIEW**
This PR adds a `short_name` value to the `config.yaml` which will overwrite the full parameter name when writing user defined parameters to an excel file. 

**LOGIC**
Adds a new utility function called `create_name_mappings( ... )` which will create a mapping dictionary similar to the previous `EXCEL_TO_CSV` hard coded dictionary. This function is called in the `ReadExcel` class only. When writing to excel, the logic just checks if there is a `short_name` value associated with the parameter or not, and writes that out. 

**QUESTIONS**
1.  The downside of only calling `create_name_mappings( ... )` when reading is that we do not log to the user if their parameter name is longer then 31 characters. I guess my justification for doing this is I tried to keep the logging within the  `create_name_mappings( ... )` function. Do you think I should break the logging out from this function, or change the logic so  `create_name_mappings( ... )` is called when writing to Excel as well? 

2. The current logic does not check if all excel tabs are in the configuration file. This could be an issue if the user modifies an excel tab name, but does not update the `short_name` in the configuration file. Do you think this is worth checking for? Or just leave it for the time being? 

4. The return type of the `create_name_mappings( ... )` function should be `Dict[str, str]`, but it really wasn't happy when I used this type. It sees the input config file as a `Dict[str, Dict[str, Union[str, List]]]`. Then at the end I use a comprehension to determine what string should be the key and value. But it just keeps throwing this error, with the types changing location due to the comprehension swapping their places. 

```bash
src/otoole/utils.py:145: error: Incompatible return value type (got "Dict[str, Union[str, List[Any]]]", expected "Dict[str, str]")
src/otoole/utils.py:148: error: Incompatible return value type (got "Dict[Union[str, List[Any]], str]", expected "Dict[str, str]")
```

For the time being I left the return type as just a `Dict`. My question is, is there a way around this, or should I not be changing the order of return types? But then I'm a little confused on why it is seeing `Dict[Union[str, List[Any]]` as one of the types, since checking the logic it comes out to be a string? I may take another look at this tomorrow haha. 

Thanks ! 

Closes #128 