### PR TITLE
Create missing params when reading from excel 

### DIFF
--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -175,6 +175,8 @@ def conversion_matrix(args):
     elif args.from_format == "excel":
         read_strategy = ReadExcel(user_config=config)
 
+    input_data, _ = read_strategy.read(args.from_path)
+
     # set write strategy
 
     write_defaults = True if args.write_defaults else False
@@ -194,7 +196,7 @@ def conversion_matrix(args):
 
     if read_strategy and write_strategy:
         context = Context(read_strategy, write_strategy)
-        context.convert(args.from_path, args.to_path)
+        context.convert(args.from_path, args.to_path, input_data=input_data)
     else:
         raise NotImplementedError(msg)
 

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -215,7 +215,12 @@ class WriteStrategy(Strategy):
 
     @abstractmethod
     def _write_parameter(
-        self, df: pd.DataFrame, parameter_name: str, handle: TextIO, default: float
+        self,
+        df: pd.DataFrame,
+        parameter_name: str,
+        handle: TextIO,
+        default: float,
+        **kwargs,
     ) -> pd.DataFrame:
         """Write parameter data"""
         raise NotImplementedError()
@@ -262,7 +267,7 @@ class WriteStrategy(Strategy):
 
             if entity_type != "set":
                 default_value = default_values[name]
-                self._write_parameter(df, name, handle, default=default_value)
+                self._write_parameter(df, name, handle, default=default_value, **kwargs)
             else:
                 self._write_set(df, name, handle)
 

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -125,6 +125,8 @@ class ReadExcel(_ReadTabular):
 
             input_data[mod_name] = narrow
 
+        input_data = self._get_missing_params(input_data)
+
         input_data = self._check_index(input_data)
 
         return input_data, default_values
@@ -155,6 +157,36 @@ class ReadExcel(_ReadTabular):
         for sheet_name in sheet_names:
             if sheet_name not in config_param_names:
                 raise OtooleExcelNameMismatchError(excel_name=sheet_name)
+
+    def _get_missing_params(
+        self, input_data: Dict[str, pd.DataFrame]
+    ) -> Dict[str, pd.DataFrame]:
+        """Creates empty dataframes for missing parameters
+
+        Arguments:
+        ----------
+        input_data: Dict[str, pd.DataFrame]
+            Data read in from the excel notebook
+
+        Returns:
+        --------
+        all_params: Dict[str, pd.DataFrame]
+            Input data plus empty dataframes for data not included in excel notebook
+        """
+
+        all_parameters = [
+            param for param, data in self.user_config.items() if data["type"] == "param"
+        ]
+        missing_params = [x for x in all_parameters if x not in input_data]
+
+        for param in missing_params:
+            indices = self.user_config[param]["indices"]
+            df = pd.DataFrame(columns=indices)
+            df.set_index(indices)
+            df["VALUE"] = ""
+            input_data[param] = df
+
+        return input_data
 
 
 class ReadCsv(_ReadTabular):

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -46,7 +46,12 @@ class DummyWriteStrategy(WriteStrategy):
         raise NotImplementedError()
 
     def _write_parameter(
-        self, df: pd.DataFrame, parameter_name: str, handle: TextIO, default: float
+        self,
+        df: pd.DataFrame,
+        parameter_name: str,
+        handle: TextIO,
+        default: float,
+        **kwargs
     ) -> pd.DataFrame:
         raise NotImplementedError()
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,10 +1,10 @@
-from typing import Any, TextIO, Union
+from typing import Any, Dict, TextIO, Tuple, Union
 
 import pandas as pd
 from pandas.testing import assert_frame_equal
 from pytest import fixture, mark, raises
 
-from otoole.input import WriteStrategy
+from otoole.input import ReadStrategy, WriteStrategy
 
 
 @fixture
@@ -40,7 +40,7 @@ def simple_input_data(region, year, technology):
     }
 
 
-# To instantiate abstract class WriteStrategy with abstract methods
+# To instantiate abstract class WriteStrategy
 class DummyWriteStrategy(WriteStrategy):
     def _header(self) -> Union[TextIO, Any]:
         raise NotImplementedError()
@@ -54,6 +54,14 @@ class DummyWriteStrategy(WriteStrategy):
         raise NotImplementedError()
 
     def _footer(self, handle: TextIO):
+        raise NotImplementedError()
+
+
+# To instantiate abstract class ReadStrategy
+class DummyReadStrategy(ReadStrategy):
+    def read(
+        self, filepath: Union[str, TextIO], **kwargs
+    ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:
         raise NotImplementedError()
 
 
@@ -254,25 +262,35 @@ class TestExpandDefaults:
                 result_data[0], write_strategy.default_values
             )
 
-    # TODO
-    # idk how to parameterize the test function to work with fixtures. Tried
-    # making all input data fixtures, then passing in the commented code,
-    # but you get an error of indexing over a fuction (ie. the fixture)
 
-    # @fixture(params=[
-    #     input_data_multi_index_no_defaults,
-    #     input_data_multi_index,
-    #     input_data_multi_index_empty,
-    #     input_data_single_index,
-    #     input_data_single_index_empty,
-    # ],
-    # ids=[
-    #     "multi_index_no_defaluts",
-    #     "multi_index",
-    #     "multi_index_empty",
-    #     "single_index",
-    #     "single_index_empty",
-    # ])
-    # def parameter_test_data(self, request):
-    #     return request.param
-    # def test_expand_parmaters_defaults(self, user_config, simple_default_values, parameter_test_data):
+class TestReadStrategy:
+    missing_input_test_data = (
+        (
+            "param",
+            "AccumulatedAnnualDemand",
+            pd.DataFrame(columns=["REGION", "FUEL", "YEAR", "VALUE"]).set_index(
+                ["REGION", "FUEL", "YEAR"]
+            ),
+        ),
+        ("set", "REGION", pd.DataFrame(columns=["VALUE"])),
+    )
+
+    @mark.parametrize(
+        "config_type, test_value, expected",
+        missing_input_test_data,
+        ids=["param", "set"],
+    )
+    def test_get_missing_input_dataframes(
+        self, user_config, config_type, test_value, expected
+    ):
+        input_data = {}
+        reader = DummyReadStrategy(user_config)
+        input_data = reader._get_missing_input_dataframes(input_data, config_type)
+        actual = input_data[test_value]
+        pd.testing.assert_frame_equal(actual, expected)
+
+    def test_get_missing_input_dataframes_excpetion(self, user_config):
+        input_data = {}
+        reader = DummyReadStrategy(user_config)
+        with raises(ValueError):
+            reader._get_missing_input_dataframes(input_data, config_type="not_valid")

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -1016,20 +1016,3 @@ class TestReadExcel:
             ).set_index(["TIMESLICE", "YEAR"])
         }
         pd.testing.assert_frame_equal(actual["YearSplit"], expected["YearSplit"])
-
-    def test_get_missing_params(self, user_config):
-
-        # scenario where AccumulatedAnnualDemand is not provided in input excel file
-        params = [x for x, y in user_config.items() if y["type"] == "param"]
-        input_data = {x: pd.DataFrame() for x in params}
-        del input_data["AccumulatedAnnualDemand"]
-
-        indices = user_config["AccumulatedAnnualDemand"]["indices"]
-        columns = indices + ["VALUE"]
-        expected = pd.DataFrame(columns=columns)
-        expected.set_index(indices)
-
-        reader = ReadExcel(user_config=user_config)
-        actual = reader._get_missing_params(input_data=input_data)
-
-        pd.testing.assert_frame_equal(actual["AccumulatedAnnualDemand"], expected)

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -62,6 +62,18 @@ class TestWriteExcel:
         # print(actual, expected)
         pd.testing.assert_frame_equal(actual, expected)
 
+    def test_form_template_paramter(self, user_config):
+        input_data = {
+            "YEAR": pd.DataFrame(data=[[2015], [2016], [2017]], columns=["VALUE"])
+        }
+        convert = WriteExcel(user_config)
+        actual = convert._form_parameter_template(
+            "AccumulatedAnnualDemand", input_data=input_data
+        )
+        expected = pd.DataFrame(columns=["REGION", "FUEL", 2015, 2016, 2017])
+
+        pd.testing.assert_frame_equal(actual, expected)
+
     def test_form_three_columns(self, user_config):
 
         convert = WriteExcel(user_config)  # typing: WriteExcel


### PR DESCRIPTION
Hello! 

# Overview
In this PR I implement logic in the `ReadExcel` class to create empty dataframes for parameters that do not have an associated excel sheet. This PR relates to issue #99, and [this comment](https://github.com/OSeMOSYS/otoole/issues/114#issuecomment-1358393751) in issue #114. 

# Problem Addressed 
I was reviewing issue #99 and encountered a very similar issue to the one described. When we convert from anything to an Excel file, only parameters that have non-default values are written. For example, in Simplicity the DiscountRate is given by a default value, therefore, no `DiscountRate` sheet will appear after running the command `otoole convert <> excel <> params.xlsx config.yaml`. 

In a different [comment](https://github.com/OSeMOSYS/otoole/issues/114#issuecomment-1358393751) (see issue #114) I discuss if this is actually the functionality we want. Or if we should be writing out empty sheets when the parameter does not have values to help guide users on how to input data. 

Nevertheless, with the current functionality, when reading in the Excel data it is not capturing parameters without dedicated sheets. For example, if no `DiscountRate` sheet exists in the excel file, then no `DiscountRate` key will be created in the otoole internal datastore. While this doesn't cause any otoole logic issues, no reference to the missing parameters will be written. This is problematic, as, for example, you will have an OSeMOSYS datafile without a `DiscountRate` parameter.   

# Logic
To fix this, I add a new function to the `ReadExcel` class called `_get_missing_params( ... )`. This function takes in the parameters read in from excel and compares them against all defined parameters in the `config.yaml` file. If a parameter is missing in the excel data, an empty dataframe is created and added to the internal datastore. Two tests are added to the `test_read_strategies.py` module to accompany this logic. 

# Other notes
Currently, this only checks parameters. A minor modification is needed if we want it to check for missing sets as well. However, I decided to hold off on adding that until we discussed if this is the correct path to go down to fix this issue :) 

Thanks! 