### PR TITLE
Deprecated default_values.csv

### DIFF
--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -6,7 +6,7 @@ import pandas as pd
 from amply import Amply
 from flatten_dict import flatten
 
-from otoole.exceptions import OtooleExcelNameMismatchError
+from otoole.exceptions import OtooleDeprecationError, OtooleExcelNameMismatchError
 from otoole.input import ReadStrategy
 from otoole.preprocess.longify_data import check_datatypes, check_set_datatype
 from otoole.utils import create_name_mappings
@@ -170,6 +170,7 @@ class ReadCsv(_ReadTabular):
 
         input_data = {}
 
+        self._check_for_default_values_csv(filepath)
         default_values = self._read_default_values(self.user_config)
 
         for parameter, details in self.user_config.items():
@@ -243,6 +244,30 @@ class ReadCsv(_ReadTabular):
             default_columns = expected_columns + ["VALUE"]
             df = pd.DataFrame(columns=default_columns)
         return df
+
+    @staticmethod
+    def _check_for_default_values_csv(filepath: str) -> None:
+        """Checks for a default values csv, which has been deprecated.
+
+        Arguments
+        ---------
+        filepath:str
+            Directory of csv files
+
+        Raises
+        ------
+        OtooleDeprecationError
+            If a default_values.csv is found in input data
+        """
+
+        default_values_csv_path = os.path.join(
+            os.path.dirname(filepath), "default_values.csv"
+        )
+        if os.path.exists(default_values_csv_path):
+            raise OtooleDeprecationError(
+                resource="data/default_values.csv",
+                message="Remove default_values.csv and define all default values in the configuration file",
+            )
 
 
 class ReadDatafile(ReadStrategy):

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -225,10 +225,4 @@ class WriteCsv(WriteStrategy):
         self._write_out_dataframe(self.filepath, set_name, df, index=False)
 
     def _footer(self, handle: TextIO):
-        # writes out default_values.csv
-        if self.default_values:
-            df = pd.DataFrame().from_dict(
-                self.default_values, orient="index", columns=["default_value"]
-            )
-            df = df.reset_index().rename({"index": "name"}, axis=1)
-            self._write_out_dataframe(self.filepath, "default_values", df, index=False)
+        pass

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -5,9 +5,10 @@ from typing import List
 
 import pandas as pd
 from amply import Amply
-from pytest import mark
+from pytest import mark, raises
 
 from otoole import ReadCsv, ReadDatafile, ReadExcel, ReadMemory
+from otoole.exceptions import OtooleDeprecationError
 from otoole.preprocess.longify_data import check_datatypes
 from otoole.results.results import (
     ReadCbc,
@@ -1047,3 +1048,21 @@ class TestReadCSV:
         actual = reader._get_input_data(filepath, parameter, details)
 
         pd.testing.assert_frame_equal(actual, expected)
+
+    def test_read_default_values_csv_fails(self, user_config, tmp_path):
+        f = tmp_path / "input/default_values.csv"
+        f.parent.mkdir()
+        f.touch()
+
+        reader = ReadCsv(user_config=user_config)
+        with raises(OtooleDeprecationError):
+            reader._check_for_default_values_csv(f)
+
+    def test_read_default_values_csv(self, user_config):
+        filepath = os.path.join(
+            "tests", "fixtures", "data", "AccumulatedAnnualDemand.csv"
+        )
+        reader = ReadCsv(user_config=user_config)
+        actual = reader._check_for_default_values_csv(filepath)
+        expected = None
+        assert actual == expected


### PR DESCRIPTION
# Overview
This PR addresses issue #139 and deprecates the reading/writing of `default_values.csv`, as all default values should be defined in the `config.yaml` file. Tests are included for the added logic. 

# Logic
In the `convert` function, if a folder of csvs is read in and a `default_values.csv` file is found, an `OtooleDeprecationError` is raised that instructs the user to define defaults in the `config.yaml` file. 

# Example
If a file called `data/default_values.csv` exists
```bash
(otoole) ~/repositories/otoole/trevor$ otoole convert csv datafile data/ test.txt config.yaml 
OtooleDeprecationError: data/default_values.csv -> Remove default_values.csv and define all default values in the configuration file
```