### PR TITLE
Add `otoole setup` commands

### DIFF
--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -41,6 +41,7 @@ Ask for help on the command line::
 import argparse
 import logging
 import os
+import shutil
 import sys
 
 from otoole import (
@@ -55,7 +56,9 @@ from otoole import (
     WriteExcel,
     __version__,
 )
+from otoole.exceptions import OtooleSetupError
 from otoole.input import Context
+from otoole.preprocess.setup import get_config_setup_data, get_csv_setup_data
 from otoole.utils import (
     _read_file,
     read_deprecated_datapackage,
@@ -264,6 +267,27 @@ def data2res(args):
     create_res(input_data, args.resfile)
 
 
+def setup(args):
+    """Creates template data"""
+
+    data_type = args.data_type
+    data_path = args.data_path
+    write_defaults = args.write_defaults
+    overwrite = args.overwrite
+
+    if os.path.exists(data_path) and not overwrite:
+        raise OtooleSetupError(resource=data_path)
+
+    if data_type == "config":
+        shutil.copyfile(os.path.join("config.yaml"), data_path)
+    elif data_type == "csv":
+        config = get_config_setup_data()
+        input_data, default_values = get_csv_setup_data(config)
+        WriteCsv(user_config=config).write(
+            input_data, data_path, default_values, write_defaults=write_defaults
+        )
+
+
 def get_parser():
     parser = argparse.ArgumentParser(
         description="otoole: Python toolkit of OSeMOSYS users"
@@ -371,6 +395,26 @@ def get_parser():
     res_parser.add_argument("resfile", help="Path to reference energy system")
     res_parser.add_argument("config", help="Path to config YAML file")
     res_parser.set_defaults(func=data2res)
+
+    # parser for setup
+    setup_parser = subparsers.add_parser("setup", help="Setup template files")
+    setup_parser.add_argument(
+        "data_type", help="Type of file to setup", choices=sorted(["config", "csv"])
+    )
+    setup_parser.add_argument("data_path", help="Path to file or folder to save to")
+    setup_parser.add_argument(
+        "--write_defaults",
+        help="Writes default values",
+        default=False,
+        action="store_true",
+    )
+    setup_parser.add_argument(
+        "--overwrite",
+        help="Overwrites existing data",
+        default=False,
+        action="store_true",
+    )
+    setup_parser.set_defaults(func=setup)
 
     return parser
 

--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -279,7 +279,10 @@ def setup(args):
         raise OtooleSetupError(resource=data_path)
 
     if data_type == "config":
-        shutil.copyfile(os.path.join("config.yaml"), data_path)
+        shutil.copyfile(
+            os.path.join(os.path.dirname(__file__), "preprocess", "config.yaml"),
+            data_path,
+        )
     elif data_type == "csv":
         config = get_config_setup_data()
         input_data, default_values = get_csv_setup_data(config)

--- a/src/otoole/exceptions.py
+++ b/src/otoole/exceptions.py
@@ -13,7 +13,6 @@ class OtooleValidationError(OtooleException):
         Name of the resource which is invalid
     message : str
         Error message
-
     """
 
     def __init__(self, resource, message):
@@ -32,7 +31,6 @@ class OtooleRelationError(OtooleException):
         Name of the resource which is invalid
     message : str
         Error message
-
     """
 
     def __init__(self, resource, foreign_resource, message):
@@ -97,10 +95,32 @@ class OtooleDeprecationError(OtooleException):
         Name of the resource which is invalid
     message : str
         Error message
-
     """
 
     def __init__(self, resource, message):
+        self.resource = resource
+        self.message = message
+
+    def __str__(self):
+        return f"{self.resource} -> {self.message}"
+
+
+class OtooleSetupError(OtooleException):
+    """Setup data already exists
+
+    Arguments
+    ---------
+    resource : str
+        Name of the resource which is invalid
+    message : str
+        Error message
+    """
+
+    def __init__(
+        self,
+        resource,
+        message="Data already exists. Delete file/directory or pass the --overwrite flag",
+    ):
         self.resource = resource
         self.message = message
 

--- a/src/otoole/preprocess/config.yaml
+++ b/src/otoole/preprocess/config.yaml
@@ -1,0 +1,517 @@
+AccumulatedAnnualDemand:
+    indices: [REGION,FUEL,YEAR]
+    type: param
+    dtype: float
+    default: 0
+AnnualEmissionLimit:
+    indices: [REGION,EMISSION,YEAR]
+    type: param
+    dtype: float
+    default: -1
+AnnualExogenousEmission:
+    indices: [REGION,EMISSION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+AvailabilityFactor:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 1
+CapacityFactor:
+    indices: [REGION,TECHNOLOGY,TIMESLICE,YEAR]
+    type: param
+    dtype: float
+    default: 1
+CapacityOfOneTechnologyUnit:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+CapacityToActivityUnit:
+    indices: [REGION,TECHNOLOGY]
+    type: param
+    dtype: float
+    default: 1
+CapitalCost:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+CapitalCostStorage:
+    indices: [REGION,STORAGE,YEAR]
+    type: param
+    dtype: float
+    default: 0
+Conversionld:
+    indices: [TIMESLICE,DAYTYPE]
+    type: param
+    dtype: float
+    default: 0
+Conversionlh:
+    indices: [TIMESLICE,DAILYTIMEBRACKET]
+    type: param
+    dtype: float
+    default: 0
+Conversionls:
+    indices: [TIMESLICE,SEASON]
+    type: param
+    dtype: float
+    default: 0
+DAILYTIMEBRACKET:
+    dtype: int
+    type: set
+DaysInDayType:
+    indices: [SEASON,DAYTYPE,YEAR]
+    type: param
+    dtype: float
+    default: 7
+DaySplit:
+    indices: [DAILYTIMEBRACKET,YEAR]
+    type: param
+    dtype: float
+    default: 0.00137
+DAYTYPE:
+    dtype: int
+    type: set
+DepreciationMethod:
+    indices: [REGION]
+    type: param
+    dtype: float
+    default: 1
+DiscountRate:
+    indices: [REGION]
+    type: param
+    dtype: float
+    default: 0.05
+DiscountRateIdv:
+    indices: [REGION,TECHNOLOGY]
+    type: param
+    dtype: float
+    default: 0.05
+DiscountRateStorage:
+    indices: [REGION,STORAGE]
+    type: param
+    dtype: float
+    default: 0.05
+EMISSION:
+    dtype: str
+    type: set
+EmissionActivityRatio:
+    indices: [REGION,TECHNOLOGY,EMISSION,MODE_OF_OPERATION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+EmissionsPenalty:
+    indices: [REGION,EMISSION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+FixedCost:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+FUEL:
+    dtype: str
+    type: set
+InputActivityRatio:
+    indices: [REGION,TECHNOLOGY,FUEL,MODE_OF_OPERATION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+MinStorageCharge:
+    indices: [REGION,STORAGE,YEAR]
+    type: param
+    dtype: float
+    default: 0
+MODE_OF_OPERATION:
+    dtype: int
+    type: set
+ModelPeriodEmissionLimit:
+    indices: [REGION,EMISSION]
+    type: param
+    dtype: float
+    default: -1
+ModelPeriodExogenousEmission:
+    indices: [REGION,EMISSION]
+    type: param
+    dtype: float
+    default: 0
+OperationalLife:
+    indices: [REGION,TECHNOLOGY]
+    type: param
+    dtype: float
+    default: 1
+OperationalLifeStorage:
+    indices: [REGION,STORAGE]
+    type: param
+    dtype: float
+    default: 0
+OutputActivityRatio:
+    indices: [REGION,TECHNOLOGY,FUEL,MODE_OF_OPERATION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+REGION:
+    dtype: str
+    type: set
+REMinProductionTarget:
+    indices: [REGION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+ReserveMargin:
+    indices: [REGION,YEAR]
+    type: param
+    dtype: float
+    default: 1
+ReserveMarginTagFuel:
+    indices: [REGION,FUEL,YEAR]
+    type: param
+    dtype: float
+    default: 0
+ReserveMarginTagTechnology:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+ResidualCapacity:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+ResidualStorageCapacity:
+    indices: [REGION,STORAGE,YEAR]
+    type: param
+    dtype: float
+    default: 999
+RETagFuel:
+    indices: [REGION,FUEL,YEAR]
+    type: param
+    dtype: float
+    default: 0
+RETagTechnology:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+SEASON:
+    dtype: int
+    type: set
+SpecifiedAnnualDemand:
+    indices: [REGION,FUEL,YEAR]
+    type: param
+    dtype: float
+    default: 0
+SpecifiedDemandProfile:
+    indices: [REGION,FUEL,TIMESLICE,YEAR]
+    type: param
+    dtype: float
+    default: 0
+STORAGE:
+    dtype: str
+    type: set
+StorageLevelStart:
+    indices: [REGION,STORAGE]
+    type: param
+    dtype: float
+    default: 0
+StorageMaxChargeRate:
+    indices: [REGION,STORAGE]
+    type: param
+    dtype: float
+    default: 0
+StorageMaxDischargeRate:
+    indices: [REGION,STORAGE]
+    type: param
+    dtype: float
+    default: 0
+TECHNOLOGY:
+    dtype: str
+    type: set
+TechnologyFromStorage:
+    indices: [REGION,TECHNOLOGY,STORAGE,MODE_OF_OPERATION]
+    type: param
+    dtype: float
+    default: 0
+TechnologyToStorage:
+    indices: [REGION,TECHNOLOGY,STORAGE,MODE_OF_OPERATION]
+    type: param
+    dtype: float
+    default: 0
+TIMESLICE:
+    dtype: str
+    type: set
+TotalAnnualMaxCapacity:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: -1
+TotalAnnualMaxCapacityInvestment:
+    short_name: TotalAnnualMaxCapacityInvestmen
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: -1
+TotalAnnualMinCapacity:
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+TotalAnnualMinCapacityInvestment:
+    short_name: TotalAnnualMinCapacityInvestmen
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+TotalTechnologyAnnualActivityLowerLimit:
+    short_name: TotalTechnologyAnnualActivityLo
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: 0
+TotalTechnologyAnnualActivityUpperLimit:
+    short_name: TotalTechnologyAnnualActivityUp
+    indices: [REGION,TECHNOLOGY,YEAR]
+    type: param
+    dtype: float
+    default: -1
+TotalTechnologyModelPeriodActivityLowerLimit:
+    short_name: TotalTechnologyModelPeriodActLo
+    indices: [REGION,TECHNOLOGY]
+    type: param
+    dtype: float
+    default: 0
+TotalTechnologyModelPeriodActivityUpperLimit:
+    short_name: TotalTechnologyModelPeriodActUp
+    indices: [REGION,TECHNOLOGY]
+    type: param
+    dtype: float
+    default: -1
+TradeRoute:
+    indices: [REGION,FUEL,YEAR]
+    type: param
+    dtype: float
+    default: 0
+VariableCost:
+    indices: [REGION,TECHNOLOGY,MODE_OF_OPERATION,YEAR]
+    type: param
+    dtype: float
+    default: 0
+YEAR:
+    dtype: int
+    type: set
+YearSplit:
+    indices: [TIMESLICE,YEAR]
+    type: param
+    dtype: float
+    default: 0
+AnnualEmissions:
+    indices: [REGION,EMISSION,YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+AccumulatedNewCapacity:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+AnnualFixedOperatingCost:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+AnnualTechnologyEmission:
+    indices: [REGION, TECHNOLOGY, EMISSION, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+AnnualTechnologyEmissionByMode:
+    indices: [REGION, TECHNOLOGY, EMISSION, MODE_OF_OPERATION, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+AnnualVariableOperatingCost:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+CapitalInvestment:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+Demand:
+    indices: [REGION, TIMESLICE, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+DiscountedSalvageValue:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+DiscountedTechnologyEmissionsPenalty:
+    short_name: DiscountedTechEmissionsPenalty
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+NewCapacity:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+NewStorageCapacity:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+NumberOfNewTechnologyUnits:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+ProductionByTechnology:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+ProductionByTechnologyAnnual:
+    indices: [REGION, TECHNOLOGY, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+RateOfActivity:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, MODE_OF_OPERATION, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+RateOfProductionByTechnology:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+RateOfProductionByTechnologyByMode:
+    short_name: RateOfProductionByTechByMode
+    indices: [REGION, TIMESLICE, TECHNOLOGY, MODE_OF_OPERATION, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+RateOfUseByTechnology:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+RateOfUseByTechnologyByMode:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, MODE_OF_OPERATION, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+SalvageValue:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+SalvageValueStorage:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelDayTypeFinish:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelDayTypeStart:
+    indices: [REGION, STORAGE, SEASON, DAYTYPE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelSeasonStart:
+    indices: [REGION, STORAGE, SEASON, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearStart:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+StorageLevelYearFinish:
+    indices: [REGION, STORAGE, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+TotalAnnualTechnologyActivityByMode:
+    short_name: TotalAnnualTechActivityByMode
+    indices: [REGION, TECHNOLOGY, MODE_OF_OPERATION, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+TotalCapacityAnnual:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+TotalDiscountedCost:
+    indices: [REGION,YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+TotalTechnologyAnnualActivity:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+TotalTechnologyModelPeriodActivity:
+    short_name: TotalTechModelPeriodActivity
+    indices: [REGION, TECHNOLOGY]
+    type: result
+    dtype: float
+    default: 0
+    calculated: True
+Trade:
+    indices: [REGION, REGION, TIMESLICE, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False
+UseByTechnology:
+    indices: [REGION, TIMESLICE, TECHNOLOGY, FUEL, YEAR]
+    type: result
+    dtype: float
+    default: 0
+    calculated: False

--- a/src/otoole/preprocess/setup.py
+++ b/src/otoole/preprocess/setup.py
@@ -1,0 +1,44 @@
+"""Module to create template data"""
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+from otoole.read_strategies import ReadCsv
+from otoole.utils import read_packaged_file
+
+
+def get_csv_setup_data(
+    config: Dict[str, Any]
+) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:
+    """Gets template dataframe data to write as csvs
+
+    Arguments
+    ---------
+    config: Dict[str,Any]
+        Configuration data to get CSV data to match against
+
+    Returns
+    -------
+    Dict[str: pd.DataFrame]
+        Parameters with empty template dataframes
+    Dict[str: Any]
+        Default values extracted from config file
+    """
+
+    input_data: Dict[str, pd.DataFrame] = {}
+
+    reader = ReadCsv(user_config=config)
+
+    for config_type in ["param", "set"]:
+        input_data = reader._get_missing_input_dataframes(
+            input_data, config_type=config_type
+        )
+    input_data = reader._check_index(input_data)
+    default_values = reader._read_default_values(config)
+
+    return input_data, default_values
+
+
+def get_config_setup_data() -> Dict[str, Any]:
+    """Reads in template config data"""
+    return read_packaged_file("config.yaml", "otoole.preprocess")

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -196,7 +196,6 @@ class WriteCsv(WriteStrategy):
         df : pandas.DataFrame
         index : bool, default=False
             Write the index to CSV
-
         """
         filepath = os.path.join(folder, parameter + ".csv")
         with open(filepath, "w", newline="") as csvfile:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,3 +115,41 @@ class TestConvert:
         ]
         actual = run(commands, capture_output=True)
         assert actual.returncode == 0
+
+
+class TestSetup:
+
+    temp = mkdtemp()
+    temp_config = NamedTemporaryFile(suffix=".yaml")
+
+    test_data = [
+        (
+            [
+                "otoole",
+                "-v",
+                "setup",
+                "config",
+                NamedTemporaryFile(suffix=".yaml").name,
+            ],
+            "",
+        ),
+        (["otoole", "-v", "setup", "config", temp_config.name, "--overwrite"], ""),
+    ]
+
+    @mark.parametrize(
+        "commands,expected", test_data, ids=["setup", "setup_with_overwrite"]
+    )
+    def test_setup_commands(self, commands, expected):
+        actual = run(commands, capture_output=True)
+        assert expected in str(actual.stdout)
+        print(" ".join(commands))
+        assert actual.returncode == 0, print(actual.stdout)
+
+    test_errors = [
+        (["otoole", "-v", "setup", "config", temp_config.name], "OtooleSetupError"),
+    ]
+
+    @mark.parametrize("commands,expected", test_errors, ids=["setup_fails"])
+    def test_setup_error(self, commands, expected):
+        actual = run(commands, capture_output=True)
+        assert expected in str(actual.stderr)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,66 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from otoole.preprocess.setup import get_csv_setup_data
+
+
+def test_get_csv_setup_data():
+    config = {
+        "AccumulatedAnnualDemand": {
+            "indices": ["REGION", "FUEL", "YEAR"],
+            "type": "param",
+            "dtype": "float",
+            "default": 0,
+        },
+        "REGION": {
+            "dtype": "str",
+            "type": "set",
+        },
+        "FUEL": {
+            "dtype": "str",
+            "type": "set",
+        },
+        "YEAR": {
+            "dtype": "int",
+            "type": "set",
+        },
+        "Demand": {
+            "indices": ["REGION", "TIMESLICE", "FUEL", "YEAR"],
+            "type": "result",
+            "dtype": "float",
+            "default": 0,
+            "calculated": True,
+        },
+    }
+
+    accumulated_annual_demand = pd.DataFrame(
+        columns=["REGION", "FUEL", "YEAR", "VALUE"]
+    ).astype(
+        {
+            "REGION": "str",
+            "FUEL": "str",
+            "YEAR": "int64",
+            "VALUE": "float",
+        }
+    )
+    expected_inputs = {
+        "AccumulatedAnnualDemand": accumulated_annual_demand.set_index(
+            ["REGION", "FUEL", "YEAR"]
+        ),
+        "REGION": pd.DataFrame(columns=["VALUE"]),
+        "FUEL": pd.DataFrame(columns=["VALUE"]),
+        "YEAR": pd.DataFrame(columns=["VALUE"]),
+    }
+    expected_defaults = {
+        "AccumulatedAnnualDemand": 0,
+        "Demand": 0,
+    }
+    actual_inputs, actual_defaults = get_csv_setup_data(config)
+
+    assert_frame_equal(
+        actual_inputs["AccumulatedAnnualDemand"],
+        expected_inputs["AccumulatedAnnualDemand"],
+    )
+    assert_frame_equal(actual_inputs["REGION"], expected_inputs["REGION"])
+    assert "Demand" not in actual_inputs
+    assert actual_defaults == expected_defaults


### PR DESCRIPTION
# Overview 
In this PR I have added `setup` functionality to create a template user configuration file and template CSV files. If the user tries to create the template file(s) and an existing version already exists, they must pass an `--overwrite` flag. This prevents the accidental overwrite of data that is not backed up! Tests have been added for the new functionality. 

Completes one of the tasks in issue #56 

# Help info 

```bash
(otoole) ~/repositories/otoole$ otoole setup --help
usage: otoole setup [-h] [--write_defaults] [--overwrite] {config,csv} data_path

positional arguments:
  {config,csv}      Type of file to setup
  data_path         Path to file or folder to save to

optional arguments:
  -h, --help        show this help message and exit
  --write_defaults  Writes default values
  --overwrite       Overwrites existing data
```

# Examples

## Create a template user configuration file called `config.yaml`
```bash
(otoole) ~$ cat config.yaml
cat: config.yaml: No such file or directory
(otoole) ~$ otoole setup config config.yaml
(otoole) ~$ cat config.yaml
AccumulatedAnnualDemand:
    indices: [REGION,FUEL,YEAR]
    type: param
    dtype: float
    default: 0
AnnualEmissionLimit:
    indices: [REGION,EMISSION,YEAR]
    type: param
    dtype: float
    default: -1
...
```

## Create a template folder of input CSV data, in a folder called `data`
```bash
(otoole) ~$ ls data
ls: cannot access 'data': No such file or directory
(otoole) ~$ otoole setup csv data
(otoole) ~$ ls data
AccumulatedAnnualDemand.csv
AnnualEmissionLimit.csv
...

(otoole) ~$ cat data/AccumulatedAnnualDemand.csv
REGION,FUEL,YEAR,VALUE
(otoole) ~$ cat data/AnnualEmissionLimit.csv
REGION,EMISSION,YEAR,VALUE
```

## Create a template configuration file called `config.yaml` in a location where a file called `config.yaml` already exists 
Below demonstrates overwrite checks for the config file, but the same error will be raised if a folder of CSVs is written to and the folder name already exists 

```bash
(otoole) ~$ otoole setup config config.yaml
OtooleSetupError: config.yaml -> Data already exists. Delete file/directory or pass the --overwrite flag
(otoole) ~$ otoole setup config config.yaml --overwrite
(otoole) ~$ 
```

# Documentation 
Will add to the `v1.0` doc updates in PR #137 