### PR TITLE
Excel template headers bug

### DIFF
--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -170,11 +170,11 @@ def conversion_matrix(args):
 
     Implemented conversion functions::
 
-        from\to     ex cs dp df
-        -----------------------
-        excel       -- yy -- --
-        csv         nn -- yy nn
-        datafile    nn -- yy --
+        from\to     ex cs df
+        --------------------
+        excel       -- yy --
+        csv         nn -- nn
+        datafile    nn -- --
 
     """
 
@@ -223,7 +223,9 @@ def conversion_matrix(args):
         to_path = os.path.join(os.path.dirname(to_path), "data")
         write_strategy = WriteCsv(user_config=config, write_defaults=write_defaults)
     elif args.to_format == "excel":
-        write_strategy = WriteExcel(user_config=config, write_defaults=write_defaults)
+        write_strategy = WriteExcel(
+            user_config=config, write_defaults=write_defaults, input_data=input_data
+        )
     elif args.to_format == "datafile":
         write_strategy = WriteDatafile(
             user_config=config, write_defaults=write_defaults

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -185,6 +185,7 @@ class WriteStrategy(Strategy):
         filepath: Optional[str] = None,
         default_values: Optional[Dict] = None,
         write_defaults: bool = False,
+        input_data: Optional[Dict[str, pd.DataFrame]] = None,
     ):
         super().__init__(user_config=user_config)
         if filepath:
@@ -196,6 +197,11 @@ class WriteStrategy(Strategy):
             self.default_values = default_values
         else:
             self.default_values = {}
+
+        if input_data:
+            self.input_data = input_data
+        else:
+            self.input_data = {}
 
         self.write_defaults = write_defaults
 
@@ -257,7 +263,9 @@ class WriteStrategy(Strategy):
 
             if entity_type != "set":
                 default_value = default_values[name]
-                self._write_parameter(df, name, handle, default=default_value, **kwargs)
+                self._write_parameter(
+                    df, name, handle, default=default_value, input_data=self.input_data
+                )
             else:
                 self._write_set(df, name, handle)
 

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -67,13 +67,14 @@ class WriteExcel(WriteStrategy):
         pd.DataFrame
         """
 
+        indices = self.user_config[parameter_name]["indices"]
+
         if "input_data" not in kwargs:
-            logger.debug(f"Can not write excel template file for {parameter_name}")
-            return pd.DataFrame()
+            logger.debug(f"Can not pivot excel template for {parameter_name}")
+            return pd.DataFrame(columns=indices)
         else:
             input_data = kwargs["input_data"]
 
-        indices = self.user_config[parameter_name]["indices"]
         if "YEAR" in indices:
             years = input_data["YEAR"]["VALUE"].to_list()
             indices.remove("YEAR")


### PR DESCRIPTION
In this PR I fix a bug that caused the excel column names not to be written out if the dataframe is empty. 

The issue was that we were passing over the entire dataframe if no input data was found, rather then passing over only the pivoting of the years logic if no input data is found. 