### PR TITLE
Whitespace removal on reading in of data 

### DIFF
--- a/src/otoole/cli.py
+++ b/src/otoole/cli.py
@@ -199,6 +199,8 @@ def conversion_matrix(args):
 
     # set read strategy
 
+    keep_whitespace = True if args.keep_whitespace else False
+
     if args.from_format == "datafile":
         read_strategy = ReadDatafile(user_config=config)
     elif args.from_format == "datapackage":
@@ -206,11 +208,11 @@ def conversion_matrix(args):
             "Reading from datapackage is deprecated, trying to read from CSVs"
         )
         from_path = read_deprecated_datapackage(from_path)
-        read_strategy = ReadCsv(user_config=config)
+        read_strategy = ReadCsv(user_config=config, keep_whitespace=keep_whitespace)
     elif args.from_format == "csv":
-        read_strategy = ReadCsv(user_config=config)
+        read_strategy = ReadCsv(user_config=config, keep_whitespace=keep_whitespace)
     elif args.from_format == "excel":
-        read_strategy = ReadExcel(user_config=config)
+        read_strategy = ReadExcel(user_config=config, keep_whitespace=keep_whitespace)
 
     input_data, _ = read_strategy.read(args.from_path)
 
@@ -363,6 +365,12 @@ def get_parser():
     convert_parser.add_argument(
         "--write_defaults",
         help="Writes default values",
+        default=False,
+        action="store_true",
+    )
+    convert_parser.add_argument(
+        "--keep_whitespace",
+        help="Keeps leading/trailing whitespace in CSV files",
         default=False,
         action="store_true",
     )

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -235,9 +235,13 @@ class ReadCsv(_ReadTabular):
             CSV data as a dataframe
         """
         csv_path = os.path.join(filepath, parameter + ".csv")
+        if details["type"] == "param":
+            converter = {x: str.strip for x in details["indices"]}
+        else:
+            converter = {}
 
         try:
-            df = pd.read_csv(csv_path)
+            df = pd.read_csv(csv_path, converters=converter)
         except pd.errors.EmptyDataError:
             logger.error("No data found in file for %s", parameter)
             expected_columns = details["indices"]

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -235,13 +235,8 @@ class ReadCsv(_ReadTabular):
             CSV data as a dataframe
         """
         csv_path = os.path.join(filepath, parameter + ".csv")
-        if details["type"] == "param":
-            converter = {x: str.strip for x in details["indices"]}
-        else:
-            converter = {}
-
         try:
-            df = pd.read_csv(csv_path, converters=converter)
+            df = pd.read_csv(csv_path, skipinitialspace=True)
         except pd.errors.EmptyDataError:
             logger.error("No data found in file for %s", parameter)
             expected_columns = details["indices"]

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, List, TextIO, Tuple, Union
+from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 
 import pandas as pd
 from amply import Amply
@@ -34,6 +34,10 @@ class ReadMemory(ReadStrategy):
 
 
 class _ReadTabular(ReadStrategy):
+    def __init__(self, user_config: Dict[str, Dict], keep_whitespace: bool = True):
+        super().__init__(user_config)
+        self.keep_whitespace = keep_whitespace
+
     def _check_set(self, df: pd.DataFrame, config_details: Dict, name: str):
 
         logger.info("Checking set %s", name)
@@ -85,6 +89,24 @@ class _ReadTabular(ReadStrategy):
         logger.debug("Final all headers for %s: %s", name, all_headers)
 
         return narrow[all_headers].set_index(expected_headers)
+
+    def _whitespace_converter(self, indices: List[str]) -> Dict[str, Any]:
+        """Creates converter for striping whitespace in dataframe
+
+        Arguments
+        ---------
+        indicies: List[str]
+            Column headers of dataframe
+
+        Returns
+        -------
+        Dict[str,Any]
+            Converter dictionary
+        """
+        if self.keep_whitespace:
+            return {}
+        else:
+            return {x: str.strip for x in indices}
 
 
 class ReadExcel(_ReadTabular):
@@ -177,9 +199,13 @@ class ReadCsv(_ReadTabular):
             logger.info("Looking for %s", parameter)
 
             entity_type = details["type"]
+            try:
+                converter = self._whitespace_converter(details["indices"])
+            except KeyError:  # sets don't have indices def
+                converter = self._whitespace_converter(["VALUE"])
 
             if entity_type == "param":
-                df = self._get_input_data(filepath, parameter, details)
+                df = self._get_input_data(filepath, parameter, details, converter)
                 narrow = self._check_parameter(df, details["indices"], parameter)
                 if not narrow.empty:
                     narrow_checked = check_datatypes(
@@ -189,7 +215,7 @@ class ReadCsv(_ReadTabular):
                     narrow_checked = narrow
 
             elif entity_type == "set":
-                df = self._get_input_data(filepath, parameter, details)
+                df = self._get_input_data(filepath, parameter, details, converter)
                 narrow = self._check_set(df, details, parameter)
                 if not narrow.empty:
                     narrow_checked = check_set_datatype(
@@ -214,9 +240,7 @@ class ReadCsv(_ReadTabular):
 
     @staticmethod
     def _get_input_data(
-        filepath: str,
-        parameter: str,
-        details: Dict,
+        filepath: str, parameter: str, details: Dict, converter: Optional[Dict] = None
     ) -> pd.DataFrame:
         """Reads in and checks CSV data format.
 
@@ -234,9 +258,10 @@ class ReadCsv(_ReadTabular):
         pd.DataFrame
             CSV data as a dataframe
         """
+        converter = {} if not converter else converter
         csv_path = os.path.join(filepath, parameter + ".csv")
         try:
-            df = pd.read_csv(csv_path, skipinitialspace=True)
+            df = pd.read_csv(csv_path, converters=converter)
         except pd.errors.EmptyDataError:
             logger.error("No data found in file for %s", parameter)
             expected_columns = details["indices"]

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -34,7 +34,7 @@ class ReadMemory(ReadStrategy):
 
 
 class _ReadTabular(ReadStrategy):
-    def __init__(self, user_config: Dict[str, Dict], keep_whitespace: bool = True):
+    def __init__(self, user_config: Dict[str, Dict], keep_whitespace: bool = False):
         super().__init__(user_config)
         self.keep_whitespace = keep_whitespace
 

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -1066,3 +1066,28 @@ class TestReadCSV:
         actual = reader._check_for_default_values_csv(filepath)
         expected = None
         assert actual == expected
+
+
+class TestReadTabular:
+    """Methods shared for csv and excel"""
+
+    test_data = [
+        (True, ["REGION", "TECHNOLOGY"], {}),
+        (
+            False,
+            ["REGION", "TECHNOLOGY"],
+            {"REGION": str.strip, "TECHNOLOGY": str.strip},
+        ),
+    ]
+
+    @mark.parametrize(
+        "keep_whitespace, indices, expected",
+        test_data,
+        ids=["create_empty", "create_full"],
+    )
+    def test_whitespace_converter(
+        self, user_config, keep_whitespace, indices, expected
+    ):
+        reader = ReadCsv(user_config=user_config, keep_whitespace=keep_whitespace)
+        actual = reader._whitespace_converter(indices)
+        assert actual == expected


### PR DESCRIPTION
**THIS IS A DRAFT PR** 

# Overview
Hi! I was chatting with @tniet the other day about a workflow that is breaking due to whitespace in a CSV file (see example below). We quickly discussed using `otoole` to strip out whitespace when writing to the datafile. However, thinking about this solution a little more, Im not sure this functionality should be included in `otoole`. 

When whitespace is included in the input data, `otoole` still behaves as expected; it converts the data without raising an error. If we start using otoole to format input data (even just striping out whitespace), this seems outside `otoole`'s scope of work - which my understanding is just data conversion, data visualizaion, and data validation through a config file.

With that said, I have pushed a quick (draft) fix of what a solution could look like to spur discussion around this topic 🙂 **My opinion is that we should close this PR, though.** Instead we should direct the user to use the validation functionality of `otoole` and/or fix the whitspace in their own data processing? Do you have any thoughts on this @tniet, @willu47, or others?   

If I am in the minority here though, I am happy to clean up the PR (update logic to fix failing tests, add new test, ect... ) and merge it! 🙂

# Example

## Current Functionality 

If a CSV is formatted as follows (notice the white space in front of the ` ETH`)
```
REGION,FUEL,YEAR,VALUE
SIMPLICITY, ETH,2014,1.0
SIMPLICITY, ETH,2015,1.03
SIMPLICITY, ETH,2016,1.061
SIMPLICITY, ETH,2017,1.093
SIMPLICITY, ETH,2018,1.126
```
Running the command `otoole convert csv datafile ...`, the following datafile will be created
```
param default 0 : AccumulatedAnnualDemand :=
SIMPLICITY " ETH" 2014 1
SIMPLICITY " ETH" 2015 1.03
SIMPLICITY " ETH" 2016 1.061
SIMPLICITY " ETH" 2017 1.093
SIMPLICITY " ETH" 2018 1.126
```
If you try to build this file, you get the following error, since `" ETH"` is not defined.
```
osemosys_fast_1.0.1.txt:390: AccumulatedAnnualDemand[SIMPLICITY,' ETH',2014] out of domain
MathProg model processing error
```

## Proposed Functionality 
If a CSV is formatted as follows (notice the white space in front of the ` ETH`)
```
REGION,FUEL,YEAR,VALUE
SIMPLICITY, ETH,2014,1.0
SIMPLICITY, ETH,2015,1.03
SIMPLICITY, ETH,2016,1.061
SIMPLICITY, ETH,2017,1.093
SIMPLICITY, ETH,2018,1.126
```
Running the command `otoole convert csv datafile ...`, the following datafile will be created
```
param default 0 : AccumulatedAnnualDemand :=
SIMPLICITY ETH 2014 1
SIMPLICITY ETH 2015 1.03
SIMPLICITY ETH 2016 1.061
SIMPLICITY ETH 2017 1.093
SIMPLICITY ETH 2018 1.126
```
This datafile will build fine with the `glpsol` command. 

Thanks all! 