### PR TITLE
Update config template

### DIFF
--- a/src/otoole/preprocess/config.yaml
+++ b/src/otoole/preprocess/config.yaml
@@ -84,11 +84,6 @@ DiscountRate:
     type: param
     dtype: float
     default: 0.05
-DiscountRateIdv:
-    indices: [REGION,TECHNOLOGY]
-    type: param
-    dtype: float
-    default: 0.05
 DiscountRateStorage:
     indices: [REGION,STORAGE]
     type: param


### PR DESCRIPTION
Remove the `DiscountRateIdv` value from the template configuration file, as this is just assigned to the same value as the `DiscountRate` parameter in the current OSeMOSYS versions. The user can add this parameter into the config file if they want custom `DiscountRateIdv` values