### PR TITLE
Downgrade Pandas 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ flatten_dict
 importlib_resources; python_version<'3.7'
 networkx
 openpyxl
-pandas
-pandas_datapackage_reader
+pandas<2.0
 pydantic
 pydot
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     pyyaml
     pydot
     importlib_resources; python_version<'3.7'
-    pandas>=1.1
+    pandas>=1.1, <2.0
     amply>=0.1.4
     networkx
     flatten_dict


### PR DESCRIPTION
With the recent release of `pandas 2.0`, some tests in otoole are failing. Seems like the failing tests are caused by some regular expressions and data type inconsistencies. Constraining pandas to `pandas<2.0` (which results in installing `pandas 1.5.3`) all tests work fine. 