### PR TITLE
Minor typos and improved error message for multiple names

### DIFF
--- a/src/otoole/exceptions.py
+++ b/src/otoole/exceptions.py
@@ -1,3 +1,6 @@
+from typing import List, Union
+
+
 class OtooleException(Exception):
     """Base class for all otoole exceptions."""
 
@@ -77,15 +80,20 @@ class OtooleNameMismatchError(OtooleException):
 
     def __init__(
         self,
-        name: str,
-        message: str = "Name not consistent between data and config file",
+        name: Union[List, str],
     ) -> None:
-        self.name = name
-        self.message = message
+        if isinstance(name, list):
+            self.message = "Names not consistent between data and config file"
+            self.name = ", ".join(sorted(name))
+        elif isinstance(name, str):
+            self.name = name
+            self.message = "Name not consistent between data and config file"
+        else:
+            raise TypeError("Incorrect type passed to OtooleNameMismatchError")
         super().__init__(self.message)
 
     def __str__(self):
-        return f"{self.name} -> {self.message}"
+        return f"{self.message}:\n\n{self.name}.\n\nUpdate config or data with matching names."
 
 
 class OtooleDeprecationError(OtooleException):

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -418,7 +418,7 @@ class ReadStrategy(Strategy):
 
         actual_indices = df.index.names
         if actual_indices[0] is None:  # for ReadMemory
-            logger.debug(f"No mulit-index identified for {name}")
+            logger.debug(f"No multi-index identified for {name}")
             actual_indices = list(df)[:-1]  # Drop "VALUE"
 
         logger.debug(f"Actual indices for {name} are {actual_indices}")
@@ -426,7 +426,7 @@ class ReadStrategy(Strategy):
             expected_indices = config["indices"]
             logger.debug(f"Expected indices for {name} are {expected_indices}")
         except KeyError:
-            logger.debug(f"No expected indices identifed for {name}")
+            logger.debug(f"No expected indices identified for {name}")
             return
 
         if actual_indices == expected_indices:
@@ -576,7 +576,7 @@ class ReadStrategy(Strategy):
         errors = list(set(expected).symmetric_difference(set(names)))
         if errors:
             logger.debug(f"data and config name errors are: {errors}")
-            raise OtooleNameMismatchError(name=errors[0])
+            raise OtooleNameMismatchError(name=errors)
 
     @abstractmethod
     def read(


### PR DESCRIPTION
Improves error reporting when there are multiple mismatches between data and config.

### Description
Modified the `OtooleNameMismatchError` to better handle lists of names.


### Issue Ticket Number
None


### Documentation
None
