### PR TITLE
Updates dtype casting when reading in data 

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -343,9 +343,9 @@ class TestReadStrategy:
 
     capex_incorrect_dtype = pd.DataFrame(
         data=[
-            ["SIMPLICITY", "NGCC", "2014", 1.23],
-            ["SIMPLICITY", "NGCC", "2015", 2.34],
-            ["SIMPLICITY", "NGCC", "2016", 3.45],
+            ["SIMPLICITY", "NGCC", "2014", "1.23"],
+            ["SIMPLICITY", "NGCC", 2015.0, 2.34],
+            ["SIMPLICITY", "NGCC", "2016.0", 3.45],
         ],
         columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
     ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
@@ -365,7 +365,9 @@ class TestReadStrategy:
         data=["2014", "2015", "2016"], columns=["VALUE"]
     )
 
-    year_incorrect_header = pd.DataFrame(data=[2014, 2015, 2016], columns=["YEAR"])
+    year_incorrect_header = pd.DataFrame(
+        data=["2014", 2015.0, "2016.0"], columns=["YEAR"]
+    )
 
     input_data_correct = (
         ({"CapitalCost": capex_correct}, capex_correct),


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
Adds a `try` `except` block to check for the exception `ValueError: invalid literal for int() with base 10:` when type casting the set indices upon reading in data. This error is raised when trying to cast a column from a `float` to an `int`. If the error is raised, the entire column is first cast as a float, then in turn cast as an int. This seems to be the normal way to deal with this error according to [stack overflow](https://stackoverflow.com/a/49088974). 

Tests for the `ReadStrategy._check_index_dtypes(..)` have been expanded to check for more datatypes as well. Previously they only tested for string->X type casting. (My bad for that 😅)

I would not exactly call this an elegant solution, since each column needs to be cast one by one if the `except` logic is entered. But this is a bit of an edge case, so I think it is probably okay for the time being. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #167 

### Documentation
<!--- Where and how has this change been documented -->
na