### PR TITLE
Excel pivoting bug fix

### DIFF
--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -40,7 +40,9 @@ class WriteExcel(WriteStrategy):
 
         total_columns = len(names)
 
-        if total_columns > 3:
+        if "YEAR" not in names:
+            pivot = df.copy()
+        elif total_columns > 3:
             logger.debug("More than 3 columns for {}: {}".format(parameter_name, names))
             rows = names[0:-2]
             columns = names[-2]

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -92,6 +92,26 @@ class TestWriteExcel:
 
         pd.testing.assert_frame_equal(actual, expected)
 
+    def test_form_no_pivot(self, user_config):
+
+        convert = WriteExcel(user_config)  # typing: WriteExcel
+
+        # Technology to/from storage data
+        data = [
+            ["SIMPLICITY", "HYD2", "DAM", 1, 0],
+            ["SIMPLICITY", "HYD2", "DAM", 2, 1],
+        ]
+
+        df = pd.DataFrame(
+            data=data,
+            columns=["REGION", "TECHNOLOGY", "STORAGE", "MODE_OF_OPERATION", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "STORAGE", "MODE_OF_OPERATION"])
+
+        actual = convert._form_parameter(df, "test_parameter", 0)
+        expected = df.copy()
+
+        pd.testing.assert_frame_equal(actual, expected)
+
     def test_write_out_empty_dataframe(self, user_config):
 
         temp_excel = NamedTemporaryFile(suffix=".xlsx")


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR I have fixed the issue of `WriteExcel._form_parameter(..)` pivoting data that is not indexed over years. An accompanying test is added for the new logic. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #171 

### Documentation
<!--- Where and how has this change been documented -->
na