### PR TITLE
Docs build fix for v1.0.3

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -30,9 +30,6 @@ The table below highlights what information is required for each ``Set``,
 ``Parameter`` and ``Result`` definition in the configuration file. Required values are
 given by **X**, while optional values are given by **(X)**.
 
-.. deprecated:: v1.0.3
-    The **Calculated** keyword is no longer needed for Result definitions
-
 +-------------+------+------------+---------+
 |             | Set  | Parameter  | Result  |
 +=============+======+============+=========+
@@ -46,6 +43,9 @@ given by **X**, while optional values are given by **(X)**.
 +-------------+------+------------+---------+
 | default     |      | X          | X       |
 +-------------+------+------------+---------+
+
+.. deprecated:: v1.0.3
+    The ``Calculated`` keyword is no longer needed for Result definitions
 
 .. WARNING::
    Names longer than 31 characters require a ``short_name`` field. This is due

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -8,6 +8,9 @@ This page explains the different data formatting options available in otoole. Fi
 the format of the user configuration file is explained. Following this, the different
 input data formats are explained.
 
+.. SEEALSO::
+   See the Simplicity_ repository for a full example of these formats
+
 User Configuration File
 -----------------------
 
@@ -140,9 +143,6 @@ Overview
 
 This section will describe how to format data for ``excel``, ``csv``, and ``datafile``
 formats.
-
-.. SEEALSO::
-   See the Simplicity_ repository for a full example of these formats
 
 Excel
 ~~~~~

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,5 @@ Jinja2<3.1
 # under `install_requires` in `setup.cfg` is also listed here!
 sphinx>=3.2.1
 sphinx-book-theme
+urllib3<2
 # sphinx_rtd_theme


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
`urllib3` recently updated to version `2` which is causing some errors with Sphinx (see the build [here](https://readthedocs.org/projects/otoole/builds/20373882/)). urllib3 community suggested locking urllib3 to `<2` until a fix is pushed. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na