### PR TITLE
Return OSeMOSYS data as an xarray.DataSet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pandas
 pydantic
 pydot
 pyyaml
+xarray
 xlrd

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     flatten_dict
     openpyxl
     pydantic
+    xarray
 [options.packages.find]
 where = src
 exclude =

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,11 +1,13 @@
 from typing import Any, Dict, TextIO, Tuple, Union
 
 import pandas as pd
+import xarray as xr
 from pandas.testing import assert_frame_equal
 from pytest import fixture, mark, raises
 
 from otoole.exceptions import OtooleIndexError, OtooleNameMismatchError
 from otoole.input import ReadStrategy, WriteStrategy
+from otoole.read_strategies import ReadMemory
 
 
 @fixture
@@ -533,3 +535,21 @@ class TestReadStrategy:
         reader = DummyReadStrategy(simple_user_config)
         with raises(OtooleNameMismatchError):
             reader._compare_read_to_expected(names=expected)
+
+
+class TestXarray:
+    def test_xarray(self, user_config):
+        """Test that xarray can be imported"""
+
+        data = [
+            ["SIMPLICITY", "ETH", 2014, 1.0],
+            ["SIMPLICITY", "RAWSUG", 2014, 0.5],
+            ["SIMPLICITY", "ETH", 2015, 1.03],
+            ["SIMPLICITY", "RAWSUG", 2015, 0.51],
+        ]
+        df = pd.DataFrame(data=data, columns=["REGION", "FUEL", "YEAR", "VALUE"])
+        parameters = {"AccumulatedAnnualDemand": df}
+
+        reader = ReadMemory(parameters, user_config)
+        actual = reader.to_xarray("")
+        assert isinstance(actual, xr.Dataset)


### PR DESCRIPTION
An inelegant implementation on the ReadStrategy class which returns an [`xarray.DataSet`](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html) object of OSeMOSYS model data

### Description

xarray.DataSet provides a number of advantages for dealing with OSeMOSYS data, including advanced filtering.

Read in the data to an xarray.DataSet::
```python
>>> reader = ReadCsv('config.yaml')
>>> ds = reader.to_xarray('my_folder_csvs')
```

Then drop years::
```python
>>> ds = ds.drop_sel(YEAR=range(2025, 2071))

```

### Issue Ticket Number
<!--- Link corresponding issue number -->
Some of the issues around indexing that aren't satisfactory in pandas were mentioned in #98 

### Documentation
<!--- Where and how has this change been documented -->
None yet.