### PR TITLE
Fixes CPEX result processing docs 

### DIFF
--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -124,12 +124,6 @@ Gurobi_ or CPLEX_ solution file together with the input data::
     The ``--input_datapackage`` and ``--input_datafile`` flags
     have been replaced by new positional arguments ``input_data_format`` and ``input_path``
 
-.. WARNING::
-    If using CPLEX_, you will need to transform and sort the solution file before
-    processing it with ``otoole``. Instructions on how to run the transformation
-    script are on the `OSeMOSYS Repository`_. After transformation, sort the file
-    with the command ``sort <solution_file> > <sorted_file>``.
-
 Setup
 -----
 The ``setup`` module in ``otoole`` allows you to generate template files to


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
Removes a warning box in the documentation stating the user must sort cplex solution files. This is no longer needed after PR #190 

### Issue Ticket Number
<!--- Link corresponding issue number -->
closes #195 

### Documentation
<!--- Where and how has this change been documented -->

Functionality page on processing results 
