### PR TITLE
Fix Tests on Windows 

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -116,7 +116,6 @@ class Context:
 
 class Strategy(ABC):
     """
-
     Arguments
     ---------
     user_config : dict, default=None
@@ -139,9 +138,9 @@ class Strategy(ABC):
                 dtypes = {}
                 for column in details["indices"] + ["VALUE"]:
                     if column == "VALUE":
-                        dtypes["VALUE"] = details["dtype"]
+                        dtypes["VALUE"] = details["dtype"] if details["dtype"] != "int" else "int64"
                     else:
-                        dtypes[column] = config[column]["dtype"]
+                        dtypes[column] = config[column]["dtype"] if config[column]["dtype"] != "int" else "int64"
                 details["index_dtypes"] = dtypes
         return config
 
@@ -482,6 +481,7 @@ class ReadStrategy(Strategy):
             logger.debug(df.head())
             # Drop empty rows
             try:
+                dtype = config["index_dtypes"] if config["index_dtypes"] != "int" else "int64" 
                 df = (
                     df.dropna(axis=0, how="all")
                     .reset_index()
@@ -492,7 +492,7 @@ class ReadStrategy(Strategy):
                 df = df.dropna(axis=0, how="all").reset_index()
                 for index, dtype in config["index_dtypes"].items():
                     if dtype == "int":
-                        df[index] = df[index].astype(float).astype(int)
+                        df[index] = df[index].astype(float).astype("int64")
                     else:
                         df[index] = df[index].astype(dtype)
                 df = df.set_index(config["indices"])

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -492,7 +492,7 @@ class ReadStrategy(Strategy):
             except ValueError:  # ValueError: invalid literal for int() with base 10:
                 df = df.dropna(axis=0, how="all").reset_index()
                 for index, dtype in config["index_dtypes"].items():
-                    if dtype == "int":
+                    if dtype == "int64":
                         df[index] = df[index].astype(float).astype("int64")
                     else:
                         df[index] = df[index].astype(dtype)

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -138,12 +138,20 @@ class Strategy(ABC):
                 dtypes = {}
                 for column in details["indices"] + ["VALUE"]:
                     if column == "VALUE":
-                        dtypes["VALUE"] = details["dtype"] if details["dtype"] != "int" else "int64"
+                        dtypes["VALUE"] = (
+                            details["dtype"] if details["dtype"] != "int" else "int64"
+                        )
                     else:
-                        dtypes[column] = config[column]["dtype"] if config[column]["dtype"] != "int" else "int64"
+                        dtypes[column] = (
+                            config[column]["dtype"]
+                            if config[column]["dtype"] != "int"
+                            else "int64"
+                        )
                 details["index_dtypes"] = dtypes
             elif details["type"] == "set":
-                details["dtype"] = details["dtype"] if details["dtype"] != "int" else "int64"
+                details["dtype"] = (
+                    details["dtype"] if details["dtype"] != "int" else "int64"
+                )
         return config
 
     @property

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -142,6 +142,8 @@ class Strategy(ABC):
                     else:
                         dtypes[column] = config[column]["dtype"] if config[column]["dtype"] != "int" else "int64"
                 details["index_dtypes"] = dtypes
+            elif details["type"] == "set":
+                details["dtype"] = details["dtype"] if details["dtype"] != "int" else "int64"
         return config
 
     @property
@@ -481,7 +483,6 @@ class ReadStrategy(Strategy):
             logger.debug(df.head())
             # Drop empty rows
             try:
-                dtype = config["index_dtypes"] if config["index_dtypes"] != "int" else "int64" 
                 df = (
                     df.dropna(axis=0, how="all")
                     .reset_index()

--- a/src/otoole/results/result_package.py
+++ b/src/otoole/results/result_package.py
@@ -858,7 +858,7 @@ def discount_factor(
     if regions and years:
         discount_rate["YEAR"] = [years]
         discount_factor = discount_rate.explode("YEAR").reset_index(level="REGION")
-        discount_factor["YEAR"] = discount_factor["YEAR"].astype(int)
+        discount_factor["YEAR"] = discount_factor["YEAR"].astype("int64")
         discount_factor["NUM"] = discount_factor["YEAR"] - discount_factor["YEAR"].min()
         discount_factor["RATE"] = discount_factor["VALUE"] + 1
         discount_factor["VALUE"] = (

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -347,7 +347,7 @@ class ReadGlpk(ReadWideResults):
         df["INDEX"] = df["INDEX"].map(lambda x: x.split("]")[0])
         df = (
             df[["ID", "NUM", "NAME", "INDEX"]]
-            .astype({"ID": str, "NUM": int, "NAME": str, "INDEX": str})
+            .astype({"ID": str, "NUM": "int64", "NAME": str, "INDEX": str})
             .reset_index(drop=True)
         )
 
@@ -425,7 +425,7 @@ class ReadGlpk(ReadWideResults):
         data = (
             data[["ID", "NUM", "STATUS", "PRIM", "DUAL"]]
             .astype(
-                {"ID": str, "NUM": int, "STATUS": str, "PRIM": float, "DUAL": float}
+                {"ID": str, "NUM": "int64", "STATUS": str, "PRIM": float, "DUAL": float}
             )
             .reset_index(drop=True)
         )

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -156,7 +156,7 @@ class WriteDatafile(WriteStrategy):
             df = self._form_parameter(df, default)
         handle.write("param default {} : {} :=\n".format(default, parameter_name))
         df.to_csv(
-            path_or_buf=handle, sep=" ", header=False, index=True, float_format="%g"
+            path_or_buf=handle, sep=" ", header=False, index=True, float_format="%g", lineterminator="\n"
         )
         handle.write(";\n")
 
@@ -171,7 +171,7 @@ class WriteDatafile(WriteStrategy):
         """
         handle.write("set {} :=\n".format(set_name))
         df.to_csv(
-            path_or_buf=handle, sep=" ", header=False, index=False, float_format="%g"
+            path_or_buf=handle, sep=" ", header=False, index=False, float_format="%g", lineterminator="\n"
         )
         handle.write(";\n")
 

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -156,7 +156,12 @@ class WriteDatafile(WriteStrategy):
             df = self._form_parameter(df, default)
         handle.write("param default {} : {} :=\n".format(default, parameter_name))
         df.to_csv(
-            path_or_buf=handle, sep=" ", header=False, index=True, float_format="%g", lineterminator="\n"
+            path_or_buf=handle,
+            sep=" ",
+            header=False,
+            index=True,
+            float_format="%g",
+            lineterminator="\n",
         )
         handle.write(";\n")
 
@@ -171,7 +176,12 @@ class WriteDatafile(WriteStrategy):
         """
         handle.write("set {} :=\n".format(set_name))
         df.to_csv(
-            path_or_buf=handle, sep=" ", header=False, index=False, float_format="%g", lineterminator="\n"
+            path_or_buf=handle,
+            sep=" ",
+            header=False,
+            index=False,
+            float_format="%g",
+            lineterminator="\n",
         )
         handle.write(";\n")
 

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -108,7 +108,7 @@ class TestReadCplex:
                 ],
                 columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
             )
-            .astype({"REGION": str, "TECHNOLOGY": str, "YEAR": int, "VALUE": float})
+            .astype({"REGION": str, "TECHNOLOGY": str, "YEAR": "int64", "VALUE": float})
             .set_index(["REGION", "TECHNOLOGY", "YEAR"])
         )
 
@@ -135,8 +135,8 @@ class TestReadCplex:
                     "REGION": str,
                     "TIMESLICE": str,
                     "TECHNOLOGY": str,
-                    "MODE_OF_OPERATION": int,
-                    "YEAR": int,
+                    "MODE_OF_OPERATION": "int64",
+                    "YEAR": "int64",
                     "VALUE": float,
                 }
             )
@@ -202,7 +202,7 @@ RateOfActivity(SIMPLICITY,ID,FEL1,1,2017) 1.68590281943611
                 ],
                 columns=["REGION", "YEAR", "VALUE"],
             )
-            .astype({"YEAR": int, "VALUE": float})
+            .astype({"YEAR": "int64", "VALUE": float})
             .set_index(["REGION", "YEAR"])
         )
 
@@ -225,7 +225,7 @@ RateOfActivity(SIMPLICITY,ID,FEL1,1,2017) 1.68590281943611
                     "VALUE",
                 ],
             )
-            .astype({"YEAR": int, "VALUE": float, "MODE_OF_OPERATION": int})
+            .astype({"YEAR": "int64", "VALUE": float, "MODE_OF_OPERATION": "int64"})
             .set_index(
                 ["REGION", "TIMESLICE", "TECHNOLOGY", "MODE_OF_OPERATION", "YEAR"]
             )
@@ -623,7 +623,7 @@ e o f
                 ["j", 1028, "RateOfActivity", "SIMPLICITY,IN,BACKSTOP1,1,2014"],
             ],
             columns=["ID", "NUM", "NAME", "INDEX"],
-        )
+        ).astype({"ID": str, "NUM": "int64", "NAME": str, "INDEX": str})
 
         pd.testing.assert_frame_equal(actual, expected)
 
@@ -726,7 +726,7 @@ class TestCleanOnRead:
                 ],
                 columns=["REGION", "FUEL", "YEAR", "VALUE"],
             )
-            .astype({"REGION": str, "FUEL": str, "YEAR": int, "VALUE": float})
+            .astype({"REGION": str, "FUEL": str, "YEAR": "int64", "VALUE": float})
             .set_index(["REGION", "FUEL", "YEAR"])
         }
 
@@ -757,7 +757,7 @@ class TestCleanOnRead:
                 ],
                 columns=["REGION", "FUEL", "YEAR", "VALUE"],
             )
-            .astype({"REGION": str, "FUEL": str, "YEAR": int, "VALUE": float})
+            .astype({"REGION": str, "FUEL": str, "YEAR": "int64", "VALUE": float})
             .set_index(["REGION", "FUEL", "YEAR"])
         }
 

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -700,7 +700,7 @@ class TestCleanOnRead:
         assert actual == {
             "REGION": "str",
             "FUEL": "str",
-            "YEAR": "int",
+            "YEAR": "int64",
             "VALUE": "float",
         }
 
@@ -834,7 +834,7 @@ class TestConfig:
                 "FUEL": "str",
                 "REGION": "str",
                 "VALUE": "float",
-                "YEAR": "int",
+                "YEAR": "int64",
             },
         }
         assert actual["AccumulatedAnnualDemand"] == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
@@ -77,16 +78,18 @@ user_config_name_errors = ["user_config_long_param_name", "user_config_long_shor
 def test_excel_name_length_error(user_config_simple, request):
     user_config = request.getfixturevalue(user_config_simple)
     write_excel = WriteExcel(user_config=user_config)
-    temp_excel = NamedTemporaryFile(suffix=".xlsx")
-    handle = pd.ExcelWriter(temp_excel.name)
-
-    with pytest.raises(OtooleExcelNameLengthError):
-        write_excel._write_parameter(
-            df=pd.DataFrame(),
-            parameter_name="ParameterNameLongerThanThirtyOneChars",
-            handle=pd.ExcelWriter(handle),
-            default=0,
-        )
+    temp_excel = NamedTemporaryFile(suffix=".xlsx", delete=False, mode="r")
+    try:
+        with pytest.raises(OtooleExcelNameLengthError):
+            write_excel._write_parameter(
+                df=pd.DataFrame(),
+                parameter_name="ParameterNameLongerThanThirtyOneChars",
+                handle=pd.ExcelWriter(temp_excel.name),
+                default=0,
+            )
+    finally:
+        temp_excel.close()
+        os.unlink(temp_excel.name)
 
 
 class TestYamlUniqueKeyReader:

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -1,4 +1,5 @@
 import io
+import os
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
@@ -114,15 +115,20 @@ class TestWriteExcel:
 
     def test_write_out_empty_dataframe(self, user_config):
 
-        temp_excel = NamedTemporaryFile(suffix=".xlsx")
-        handle = pd.ExcelWriter(temp_excel.name)
-        convert = WriteExcel(user_config)
+        temp_excel = NamedTemporaryFile(suffix=".xlsx", delete=False, mode="w")
+        try:
+            handle = pd.ExcelWriter(temp_excel.name)
+            convert = WriteExcel(user_config)
 
-        df = pd.DataFrame(
-            data=None, columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"]
-        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+            df = pd.DataFrame(
+                data=None, columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"]
+            ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
 
-        convert._write_parameter(df, "AvailabilityFactor", handle, default=0)
+            convert._write_parameter(df, "AvailabilityFactor", handle, default=0)
+        finally:
+            handle.close()
+            temp_excel.close()
+            os.unlink(temp_excel.name)
 
 
 class TestWriteDatafile:


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR I update `otoole` to fix failing tests on Windows.

Specifically this includes: 
- Explicitly setting all `int` as `int64` data types when the config file is first read in. Im not sure why, but on Windows pandas seems to set `int` as `int32`, while on Linux it will set it as `int64` (or is just not concerned about `int32` vs. `int64)`. Anyways, `int64` is explicitly set now 
- Explicitly setting `int64` for `int` datatypes in the results package (note, the config file dtypes are not accessible here) 
- Explicitly setting `int64` for `read_strategies` of solvers 
- Specify the `lineterminator` argument as `\n` when writing to csv or datafiles, as Windows will default to `\r\n`. More information [here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html)
- Fix `NamedTemporaryFile` calls in the tests on Windows. As [this](https://stackoverflow.com/a/23212515) Stack Overflow comment and [this](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) Python docs states, to open a `NamedTemporaryFile` on Windows, you must set `delete=False` and then explicitly close and delete the file. Therefore, I have wrapped all `NamedTemporaryFile` calls in tests in `try` `finally` blocks, where the `finally` code closes and deletes the temporary file. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #202 

### Documentation
<!--- Where and how has this change been documented -->
na