### PR TITLE
Update coveralls workflow to use lcov

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,6 +31,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        run: |
-          pip install --upgrade coveralls
-          coveralls --service=github
+        uses: coverallsapp/github-action@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ console_scripts =
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this pytest issue.
 addopts =
-    --cov otoole --cov-report html
+    --cov otoole --cov-report lcov
     --verbose
     -s
     # --log-cli-level=10


### PR DESCRIPTION
Update continuous integration to use the updated coveralls github workflow

Requires pytest-cov to produce report in lcov format

### Description

Updated the coveralls workflow as recommended in [the docs](https://github.com/coverallsapp/github-action/tree/v2/?tab=readme-ov-file)


### Issue Ticket Number

Closes #208 


### Documentation
<!--- Where and how has this change been documented -->
