### PR TITLE
Regression in tests caused by pandas fixed by pandas 2.1.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+(Development) Version 1.1.3
+===========================
+- Lock pandas to 2.1.4 or later
+
 Version 1.1.2
 =============
 - Update zenodo metadata for JOSS

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ flatten_dict
 Jinja2<3.1
 networkx
 openpyxl
-pandas>=1.1,<2.1
+pandas>=2.1.4
 pydantic>=2
 pydot
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     xlrd
     pyyaml
     pydot
-    pandas>=1.1,<2.1
+    pandas>=2.1.4
     Amply>=0.1.6
     networkx
     flatten_dict

--- a/src/otoole/input.py
+++ b/src/otoole/input.py
@@ -341,8 +341,11 @@ class WriteStrategy(Strategy):
             df_default["VALUE"] = default_values[name]
 
             # combine result and default value dataframe
-            df = pd.concat([data, df_default])
-            df = df[~df.index.duplicated(keep="first")]
+            if not data.empty:
+                df = pd.concat([data, df_default])
+                df = df[~df.index.duplicated(keep="first")]
+            else:
+                df = df_default
             df = df.sort_index()
             output[name] = df
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -265,7 +265,7 @@ class TestExpandDefaults:
         input_data_single_index_empty(region),
     ]
     parameter_test_data_ids = [
-        "multi_index_no_defaluts",
+        "multi_index_no_defaults",
         "multi_index",
         "multi_index_empty",
         "single_index",


### PR DESCRIPTION
Resolves the failing tests which were caused by a regression in version 2.1.0 of pandas.

### Description

I ran tests for Python 3.9 and pandas v2.1.0 through v2.1.4. All tests pass for the latest version (v2.1.4) of pandas.

The version pin has been updated to force use of pandas 2.1.4 and later.

Also, a future deprecation issue was resolved.


### Issue Ticket Number

Closes #194 


### Documentation
<!--- Where and how has this change been documented -->
