### PR TITLE
Read in zero values from cplex

### DIFF
--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -179,7 +179,7 @@ def rename_duplicate_column(index: List) -> List:
 
 
 class ReadCplex(ReadWideResults):
-    """Read a CPLEX solution file into memeory"""
+    """Read a CPLEX solution file into memory"""
 
     def _convert_to_dataframe(self, file_path: Union[str, TextIO]) -> pd.DataFrame:
         """Reads a Cplex solution file into a pandas DataFrame
@@ -193,7 +193,7 @@ class ReadCplex(ReadWideResults):
         df[["Variable", "Index"]] = df["name"].str.split("(", expand=True)
         df["Index"] = df["Index"].str.replace(")", "", regex=False)
         LOGGER.debug(df)
-        df = df[(df["value"] != 0)].reset_index().rename(columns={"value": "Value"})
+        df = df.reset_index().rename(columns={"value": "Value"})
         return df[["Variable", "Index", "Value"]].astype({"Value": float})
 
 

--- a/tests/test_read_strategies.py
+++ b/tests/test_read_strategies.py
@@ -83,8 +83,11 @@ class TestReadCplex:
         # print(actual)
         expected = pd.DataFrame(
             [
+                ["NewCapacity", "SIMPLICITY,ETHPLANT,2014", 0],
                 ["NewCapacity", "SIMPLICITY,ETHPLANT,2015", 0.030000000000000027],
                 ["NewCapacity", "SIMPLICITY,ETHPLANT,2016", 0.030999999999999917],
+                ["RateOfActivity", "SIMPLICITY,ID,GRID_EXP,1,2014", 0],
+                ["RateOfActivity", "SIMPLICITY,ID,GRID_EXP,2,2014", 0],
                 ["RateOfActivity", "SIMPLICITY,ID,HYD1,1,2020", 0.25228800000000001],
                 ["RateOfActivity", "SIMPLICITY,ID,HYD1,1,2021", 0.25228800000000001],
                 ["RateOfActivity", "SIMPLICITY,ID,HYD1,1,2022", 0.25228800000000001],
@@ -103,6 +106,7 @@ class TestReadCplex:
         expected = (
             pd.DataFrame(
                 [
+                    ["SIMPLICITY", "ETHPLANT", 2014, 0],
                     ["SIMPLICITY", "ETHPLANT", 2015, 0.030000000000000027],
                     ["SIMPLICITY", "ETHPLANT", 2016, 0.030999999999999917],
                 ],
@@ -117,6 +121,8 @@ class TestReadCplex:
         expected = (
             pd.DataFrame(
                 [
+                    ["SIMPLICITY", "ID", "GRID_EXP", 1, 2014, 0],
+                    ["SIMPLICITY", "ID", "GRID_EXP", 2, 2014, 0],
                     ["SIMPLICITY", "ID", "HYD1", 1, 2020, 0.25228800000000001],
                     ["SIMPLICITY", "ID", "HYD1", 1, 2021, 0.25228800000000001],
                     ["SIMPLICITY", "ID", "HYD1", 1, 2022, 0.25228800000000001],


### PR DESCRIPTION
Reads in zero values from the CPLEX solution file

### Description
Removes the piece of code which excluded zero values from the CPLEX solution.


### Issue Ticket Number

#214 


### Documentation

This has not been documented.
