### PR TITLE
Upgrade to mypy 1.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
   ## You can add flake8 plugins via `additional_dependencies`:
   #  additional_dependencies: [flake8-bugbear]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961  # Use the sha / tag you want to point at
+    rev: v1.9.0  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
         additional_dependencies: ['types-PyYAML']

--- a/src/otoole/convert.py
+++ b/src/otoole/convert.py
@@ -7,6 +7,7 @@ Import the convert function from the otoole package::
 >>> convert('config.yaml', 'excel', 'datafile', 'input.xlsx', 'output.dat')
 
 """
+
 import logging
 import os
 from typing import Dict, Optional, Tuple, Union
@@ -29,7 +30,7 @@ def read_results(
     from_path: str,
     input_format: str,
     input_path: str,
-    glpk_model: str = None,
+    glpk_model: Optional[str] = None,
 ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, float]]:
     """Read OSeMOSYS results from CBC, GLPK, Gurobi, or CPLEX results files
 
@@ -79,7 +80,7 @@ def convert_results(
     input_format: str,
     input_path: str,
     write_defaults: bool = False,
-    glpk_model: str = None,
+    glpk_model: Optional[str] = None,
 ) -> bool:
     """Post-process results from a CBC, CPLEX, Gurobi, or GLPK solution file into CSV format
 

--- a/src/otoole/read_strategies.py
+++ b/src/otoole/read_strategies.py
@@ -33,7 +33,7 @@ class ReadMemory(ReadStrategy):
         self._parameters = parameters
 
     def read(
-        self, filepath: Union[str, TextIO] = None, **kwargs
+        self, filepath: Union[str, TextIO, None] = None, **kwargs
     ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Any]]:
 
         config = self.user_config

--- a/src/otoole/utils.py
+++ b/src/otoole/utils.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from importlib.resources import files
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from pydantic import ValidationError
@@ -29,7 +29,7 @@ def _read_file(open_file, ending):
     return contents
 
 
-def read_packaged_file(filename: str, module_name: str = None):
+def read_packaged_file(filename: str, module_name: Optional[str] = None):
 
     _, ending = os.path.splitext(filename)
 

--- a/src/otoole/validate.py
+++ b/src/otoole/validate.py
@@ -33,7 +33,7 @@ Create a yaml validation config with the following format::
 import logging
 import re
 from collections import defaultdict
-from typing import Dict, List, Sequence
+from typing import Dict, List, Optional, Sequence
 
 import networkx.algorithms.isolate as isolate
 import pandas as pd
@@ -53,7 +53,7 @@ def check_for_duplicates(codes: Sequence) -> bool:
     return duplicate_values
 
 
-def create_schema(config: Dict[str, Dict] = None) -> Dict:
+def create_schema(config: Optional[Dict[str, Dict]] = None) -> Dict:
     """Populate the dict of schema with codes from the validation config
 
     Arguments


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR I have upgraded pre-commit to use mypy 1.9.0! 

As part of this process, mypy now prohibits implicit Optional arguments (as described by PEP 484 [here](https://peps.python.org/pep-0484/#union-types)). I have updated the code to add `Optional` type hints where required. Shoutout to[ this repo](https://github.com/hauntsaninja/no_implicit_optional) for having good docs on this issue! (Although I just did the updates manually, rather than use their package, since there were only a few places where this was an issue) 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #222 

### Documentation
<!--- Where and how has this change been documented -->
na