### PR TITLE
Added instructions to install graphviz, if needed.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -197,6 +197,8 @@ save the solution as ``simplicity.sol``. Use otoole to create a folder of CSV re
 
     $ otoole results cplex csv simplicity.sol results csv data config.yaml
 
+.. _model-visualization:
+
 Model Visualization
 -------------------
 
@@ -217,18 +219,21 @@ Run the following command, where the RES will be saved as the file ``res.png``::
 
 .. WARNING::
     If you encounter a ``graphviz`` dependency error, install it on your system
-    from the graphviz_ website (if on Windows) or via the command::
+    following instructions on the Graphviz_ website. If on Windows,
+    download the install package `from Graphviz <https://graphviz.org/download/>`_.
+    If on Mac or Linux, or running conda, use one of the following commands::
 
-        sudo apt install graphviz # if on Ubuntu
-        brew install graphviz # if on Mac
+        brew install graphviz       # if on Mac
+        sudo apt install graphviz   # if on Ubuntu
+        conda install graphviz      # if using conda
 
     To check that ``graphviz`` installed correctly, run ``dot -V`` to check the
     version::
 
-        ~$ dot -V
+        $ dot -V
         dot - graphviz version 2.43.0 (0)
 
-1. View the RES
+2. View the RES
 ~~~~~~~~~~~~~~~
 Open the newly created file, ``res.png`` and the following image should be
 displayed
@@ -503,4 +508,4 @@ will also flag it as an isolated fuel. This means the fuel is unconnected from t
 .. _CPLEX: https://www.ibm.com/products/ilog-cplex-optimization-studio/cplex-optimizer
 .. _Anaconda: https://www.anaconda.com/
 .. _Gurobi: https://www.gurobi.com/
-.. _graphviz: https://www.graphviz.org/download/
+.. _Graphviz: https://www.graphviz.org/download/

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -184,6 +184,9 @@ visualising the reference energy system through the ``vis res`` command is suppo
     including ``bmp``, ``jpg``, ``pdf``, ``png`` etc. The graphviz_ library
     used to layout the reference energy system will interpret the file ending.
 
+    Remember to check if you have already installed graphviz_ on your maching, before using this fuctionality. 
+    To install graphviz_ use ``conda install graphviz`` command.
+
 Validation
 ----------
 The validation module in ``otoole`` checks technology and fuel names against a

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -181,11 +181,13 @@ visualising the reference energy system through the ``vis res`` command is suppo
 
 .. NOTE::
     The ``resfile`` command should include a file ending used for images,
-    including ``bmp``, ``jpg``, ``pdf``, ``png`` etc. The graphviz_ library
+    including ``bmp``, ``jpg``, ``pdf``, ``png`` etc. The Graphviz_ library
     used to layout the reference energy system will interpret the file ending.
 
-    Remember to check if you have already installed graphviz_ on your maching, before using this fuctionality. 
-    To install graphviz_ use ``conda install graphviz`` command.
+.. WARNING::
+    If you encounter a Graphviz_ dependencey error, please follow Graphviz_
+    installation instructions described in the
+    :ref:`visualization examples <model-visualization>`.
 
 Validation
 ----------
@@ -220,4 +222,4 @@ the rest of the model::
 .. _CPLEX: https://www.ibm.com/products/ilog-cplex-optimization-studio/cplex-optimizer
 .. _Gurobi: https://www.gurobi.com/
 .. _`OSeMOSYS Repository`: https://github.com/OSeMOSYS/OSeMOSYS_GNU_MathProg/tree/master/scripts
-.. _graphviz: https://graphviz.org/
+.. _Graphviz: https://graphviz.org/


### PR DESCRIPTION
Added instructions to install graphviz under `docs/functionality.rst`.

### Description
I have just added few sentences in the documentation to flag the need for gaphviz to be installed, if the user wants to use the `otoole viz` functionality.

### Issue Ticket Number
No issue raised.

### Documentation
`docs/functionality.rst`