### PR TITLE
Correct CRF calcualtions for empty discount rates 

### DIFF
--- a/src/otoole/results/result_package.py
+++ b/src/otoole/results/result_package.py
@@ -775,8 +775,8 @@ def capital_recovery_factor(
 
         return numerator / denominator
 
-    if discount_rate_idv.empty:
-        raise ValueError("Cannot calculate CRF due to missing discount rate data")
+    if discount_rate_idv.empty or operational_life.empty:
+        raise ValueError("Cannot calculate PV Annuity due to missing data")
 
     if not regions and not technologies:
         return pd.DataFrame(
@@ -826,6 +826,10 @@ def pv_annuity(
         param PvAnnuity{r in REGION, t in TECHNOLOGY} :=
                 (1 - (1 + DiscountRate[r])^(-(OperationalLife[r,t]))) * (1 + DiscountRate[r]) / DiscountRate[r];
     """
+
+    if discount_rate.empty or operational_life.empty:
+        raise ValueError("Cannot calculate PV Annuity due to missing data")
+
     if regions and technologies:
         index = pd.MultiIndex.from_product(
             [regions, technologies], names=["REGION", "TECHNOLOGY"]
@@ -876,6 +880,11 @@ def discount_factor(
                 (1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
     """
 
+    if discount_rate.empty:
+        raise ValueError(
+            "Cannot calculate discount factor due to missing discount rate"
+        )
+
     if regions and years:
         discount_rate["YEAR"] = [years]
         discount_factor = discount_rate.explode("YEAR").reset_index(level="REGION")
@@ -919,6 +928,11 @@ def discount_factor_storage(
         param DiscountFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
                 (1 + DiscountRateStorage[r,s]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
     """
+
+    if discount_rate_storage.empty:
+        raise ValueError(
+            "Cannot calculate discount_factor_storage due to missing discount rate"
+        )
 
     if regions and years:
         index = pd.MultiIndex.from_product(

--- a/src/otoole/results/result_package.py
+++ b/src/otoole/results/result_package.py
@@ -775,6 +775,9 @@ def capital_recovery_factor(
 
         return numerator / denominator
 
+    if discount_rate_idv.empty:
+        raise ValueError("Cannot calculate CRF due to missing discount rate data")
+
     if not regions and not technologies:
         return pd.DataFrame(
             data=[],

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -42,15 +42,7 @@ class ReadResults(ReadStrategy):
 
         default_values = self._read_default_values(self.results_config)  # type: Dict
 
-        # need to expand discount rate for results processing
-        if "DiscountRate" in input_data:
-            input_data["DiscountRate"] = self._expand_dataframe(
-                "DiscountRate", input_data, param_default_values
-            )
-        if "DiscountRateIdv" in input_data:
-            input_data["DiscountRateIdv"] = self._expand_dataframe(
-                "DiscountRateIdv", input_data, param_default_values
-            )
+        input_data = self._expand_required_params(input_data, param_default_values)
 
         results = self.calculate_results(
             available_results, input_data
@@ -86,6 +78,24 @@ class ReadResults(ReadStrategy):
                 LOGGER.debug("Error calculating %s: %s", name, str(ex))
 
         return results
+
+    def _expand_required_params(
+        self,
+        input_data: dict[str, pd.DataFrame],
+        param_defaults: dict[str, str | int | float],
+    ) -> dict[str, pd.DataFrame]:
+        """Expands required default values for results processing"""
+
+        if "DiscountRate" in input_data:
+            input_data["DiscountRate"] = self._expand_dataframe(
+                "DiscountRate", input_data, param_defaults
+            )
+        if "DiscountRateIdv" in input_data:
+            input_data["DiscountRateIdv"] = self._expand_dataframe(
+                "DiscountRateIdv", input_data, param_defaults
+            )
+
+        return input_data
 
 
 class ReadWideResults(ReadResults):

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -83,7 +83,7 @@ class ReadResults(ReadStrategy):
     def _expand_required_params(
         self,
         input_data: dict[str, pd.DataFrame],
-        param_defaults: dict[str, str | int | float],
+        param_defaults: dict[str, Any],
     ) -> dict[str, pd.DataFrame]:
         """Expands required default values for results processing"""
 

--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -35,6 +35,7 @@ class ReadResults(ReadStrategy):
             param_default_values = self._read_default_values(self.input_config)
         else:
             input_data = {}
+            param_default_values = {}
 
         available_results = self.get_results_from_file(
             filepath, input_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,24 @@ def discount_rate_storage():
 
 
 @fixture
+def discount_rate_empty():
+    df = pd.DataFrame(
+        data=[],
+        columns=["REGION", "VALUE"],
+    ).set_index(["REGION"])
+    return df
+
+
+@fixture
+def discount_rate_idv_empty():
+    df = pd.DataFrame(
+        data=[],
+        columns=["REGION", "TECHNOLOGY", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY"])
+    return df
+
+
+@fixture
 def emission_activity_ratio():
     df = pd.DataFrame(
         data=[["SIMPLICITY", "GAS_EXTRACTION", "CO2", 1, 2014, 1.0]],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,15 @@ def discount_rate_idv_empty():
 
 
 @fixture
+def discount_rate_storage_empty():
+    df = pd.DataFrame(
+        data=[],
+        columns=["REGION", "STORAGE", "VALUE"],
+    ).set_index(["REGION", "STORAGE"])
+    return df
+
+
+@fixture
 def emission_activity_ratio():
     df = pd.DataFrame(
         data=[["SIMPLICITY", "GAS_EXTRACTION", "CO2", 1, 2014, 1.0]],

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -698,7 +698,7 @@ class TestPvAnnuity:
 
         assert_frame_equal(actual, expected)
 
-    def test_pva_null(self, discount_rate):
+    def test_pva_null(self, discount_rate, operational_life):
 
         actual = pv_annuity([], [], discount_rate, operational_life)
 
@@ -708,6 +708,15 @@ class TestPvAnnuity:
         ).set_index(["REGION", "TECHNOLOGY"])
 
         assert_frame_equal(actual, expected)
+
+    def test_pva_empty_discount_rate(
+        self, region, discount_rate_empty, operational_life
+    ):
+        technologies = ["GAS_EXTRACTION", "DUMMY"]
+        regions = region["VALUE"].to_list()
+
+        with raises(ValueError):
+            pv_annuity(regions, technologies, discount_rate_empty, operational_life)
 
 
 class TestDiscountFactor:
@@ -784,6 +793,13 @@ class TestDiscountFactor:
         ).set_index(["REGION", "YEAR"])
 
         assert_frame_equal(actual, expected)
+
+    def test_df_empty_discount_rate(self, region, year, discount_rate_empty):
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+
+        with raises(ValueError):
+            discount_factor(regions, years, discount_rate_empty, 1.0)
 
 
 class TestDiscountFactorStorage:
@@ -869,6 +885,18 @@ class TestDiscountFactorStorage:
         ).set_index(["REGION", "STORAGE", "YEAR"])
 
         assert_frame_equal(actual, expected)
+
+    def test_df_storage_empty_discount_rate(
+        self, region, year, discount_rate_storage_empty
+    ):
+        storages = ["DAM"]
+        regions = region["VALUE"].to_list()
+        years = year["VALUE"].to_list()
+
+        with raises(ValueError):
+            discount_factor_storage(
+                regions, storages, years, discount_rate_storage_empty, 1.0
+            )
 
 
 class TestResultsPackage:

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -669,6 +669,17 @@ class TestCapitalRecoveryFactor:
 
         assert_frame_equal(actual, expected)
 
+    def test_crf_empty_discount_rate(
+        self, region, discount_rate_empty, operational_life
+    ):
+        technologies = ["GAS_EXTRACTION", "DUMMY"]
+        regions = region["VALUE"].to_list()
+
+        with raises(ValueError):
+            capital_recovery_factor(
+                regions, technologies, discount_rate_empty, operational_life
+            )
+
 
 class TestPvAnnuity:
     def test_pva(self, region, discount_rate, operational_life):


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR I have addressed the failing CRF calculation if no discount rate is provided (which was partially addressed in PR #216). Following @willu47's suggestion in ticket #217, the `_expand_default()` function is used to ensure discount rate data is always passed into the CRF, PVA, and Discount Factor functions. Since handling the `DiscountRate` and `DiscountRateIdv` differences is a little confusing (imo), I also added in `ValueError` checks to the functions to check for non-empty discount rates - but these shouldnt really be needed. Just added as double check. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
closes #217 

### Documentation
<!--- Where and how has this change been documented -->
na