### PR TITLE
Fix `read_results` API docs

### DIFF
--- a/docs/convert.rst
+++ b/docs/convert.rst
@@ -34,11 +34,11 @@ See :func:`otoole.convert.convert_results` for more details
 Reading solver results into a dict of Pandas DataFrames
 -------------------------------------------------------
 
-The ``read_results`` function reads a CBC_, CLP_,
-Gurobi_ or CPLEX_ solution file into memory::
+The ``read_results`` function reads a CBC_, CLP_, Gurobi_ or CPLEX_ solution file into to a Python object.
+This allows you to then use all the features offered by Python to manipulate the data.
 
 >>> from otoole import read_results
->>> read_results('my_model.yaml', 'cbc', 'csv', 'my_model.sol', 'my_model_csvs', 'datafile', 'my_model.dat')
+>>> data, defaults = read_results('my_model.yaml', 'cbc', 'my_model.sol', 'datafile', 'my_model.dat')
 
 See :func:`otoole.convert.read_results` for more details
 


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR, the documentation for the API call for `read_results` function has been fixed. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #231 

### Documentation
<!--- Where and how has this change been documented -->
https://otoole.readthedocs.io/en/latest/convert.html#reading-solver-results-into-a-dict-of-pandas-dataframes
