### PR TITLE
Fix `CapitalInvestment` result calculation 

### DIFF
--- a/src/otoole/results/result_package.py
+++ b/src/otoole/results/result_package.py
@@ -307,11 +307,14 @@ class ResultsPackage(Mapping):
             capital_cost = self["CapitalCost"]
             new_capacity = self["NewCapacity"]
             operational_life = self["OperationalLife"]
+            discount_rate = self["DiscountRate"]
 
             if "DiscountRateIdv" in self.keys():
-                discount_rate = self["DiscountRateIdv"]
+                discount_rate_idv = self["DiscountRateIdv"]
+                if discount_rate_idv.empty:
+                    discount_rate_idv = self["DiscountRate"]
             else:
-                discount_rate = self["DiscountRate"]
+                discount_rate_idv = self["DiscountRate"]
 
             regions = self["REGION"]["VALUE"].to_list()
             technologies = self.get_unique_values_from_index(
@@ -326,7 +329,7 @@ class ResultsPackage(Mapping):
             raise KeyError(self._msg("CapitalInvestment", str(ex)))
 
         crf = capital_recovery_factor(
-            regions, technologies, discount_rate, operational_life
+            regions, technologies, discount_rate_idv, operational_life
         )
         pva = pv_annuity(regions, technologies, discount_rate, operational_life)
         capital_investment = capital_cost.mul(new_capacity, fill_value=0.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def discount_rate():
 @fixture
 def discount_rate_idv():
     df = pd.DataFrame(
-        data=[["SIMPLICITY", "GAS_EXTRACTION", 0.05], ["SIMPLICITY", "DUMMY", 0.05]],
+        data=[["SIMPLICITY", "GAS_EXTRACTION", 0.10], ["SIMPLICITY", "DUMMY", 0.10]],
         columns=["REGION", "TECHNOLOGY", "VALUE"],
     ).set_index(["REGION", "TECHNOLOGY"])
     return df

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -621,6 +621,39 @@ class TestComputeTotalAnnualCapacity:
         )
 
 
+# class TestCapitalInvestment:
+
+#     def test_calculate_captital_investment_with_dr_idv(self, capital_cost, discount_rate):
+
+#         results = {
+#             "CapitalCost": capital_cost,
+#             "NewCapacity": new_capacity,
+#             "REGION": region,
+#             "YEAR": year,
+#             "DiscountRate": discount_rate,
+#         }
+
+#         package = ResultsPackage(results)
+#         actual = package.annual_fixed_operating_cost()
+#         expected = pd.DataFrame(
+#             data=[
+#                 ["SIMPLICITY", "GAS_EXTRACTION", 2014, 2.3],
+#                 ["SIMPLICITY", "GAS_EXTRACTION", 2015, 2.3],
+#                 ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1.6],
+#                 ["SIMPLICITY", "GAS_EXTRACTION", 2017, 1.6],
+#                 ["SIMPLICITY", "DUMMY", 2014, 0.5],
+#                 ["SIMPLICITY", "DUMMY", 2015, 0.55],
+#                 ["SIMPLICITY", "DUMMY", 2016, 0.6],
+#             ],
+#             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+#         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+#         assert_frame_equal(actual, expected)
+
+#     def test_calculate_captital_investment_no_dr_idv(self):
+#         pass
+
+
 class TestCapitalRecoveryFactor:
     def test_crf(self, region, discount_rate_idv, operational_life):
 
@@ -632,8 +665,8 @@ class TestCapitalRecoveryFactor:
 
         expected = pd.DataFrame(
             data=[
-                ["SIMPLICITY", "GAS_EXTRACTION", 0.512195121],
-                ["SIMPLICITY", "DUMMY", 0.349722442],
+                ["SIMPLICITY", "GAS_EXTRACTION", 0.523809523],
+                ["SIMPLICITY", "DUMMY", 0.365558912],
             ],
             columns=["REGION", "TECHNOLOGY", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY"])

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -178,6 +178,20 @@ def total_capacity():
 
 
 @fixture
+def capital_cost():
+    df = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.23],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 2.34],
+            ["SIMPLICITY", "DUMMY", 2015, 3.45],
+            ["SIMPLICITY", "DUMMY", 2016, 4.56],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return df
+
+
+@fixture
 def fixed_cost():
     data = pd.DataFrame(
         data=[
@@ -621,37 +635,58 @@ class TestComputeTotalAnnualCapacity:
         )
 
 
-# class TestCapitalInvestment:
+class TestCapitalInvestment:
+    def test_calculate_captital_investment_with_dr_idv(
+        self, discount_rate, discount_rate_idv
+    ):
 
-#     def test_calculate_captital_investment_with_dr_idv(self, capital_cost, discount_rate):
+        results = {
+            "CapitalCost": capital_cost,
+            "NewCapacity": new_capacity,
+            "REGION": region,
+            "YEAR": year,
+            "DiscountRate": discount_rate,
+            "DiscountRateIdv": discount_rate_idv,
+        }
 
-#         results = {
-#             "CapitalCost": capital_cost,
-#             "NewCapacity": new_capacity,
-#             "REGION": region,
-#             "YEAR": year,
-#             "DiscountRate": discount_rate,
-#         }
+        package = ResultsPackage(results)
+        actual = package.capital_investment()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.6352585],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 2.0126258],
+                ["SIMPLICITY", "DUMMY", 2014, 3.2456036],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
 
-#         package = ResultsPackage(results)
-#         actual = package.annual_fixed_operating_cost()
-#         expected = pd.DataFrame(
-#             data=[
-#                 ["SIMPLICITY", "GAS_EXTRACTION", 2014, 2.3],
-#                 ["SIMPLICITY", "GAS_EXTRACTION", 2015, 2.3],
-#                 ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1.6],
-#                 ["SIMPLICITY", "GAS_EXTRACTION", 2017, 1.6],
-#                 ["SIMPLICITY", "DUMMY", 2014, 0.5],
-#                 ["SIMPLICITY", "DUMMY", 2015, 0.55],
-#                 ["SIMPLICITY", "DUMMY", 2016, 0.6],
-#             ],
-#             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
-#         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+        assert_frame_equal(actual, expected)
 
-#         assert_frame_equal(actual, expected)
+    def test_calculate_captital_investment_no_dr_idv(
+        self, discount_rate, discount_rate_idv_empty
+    ):
 
-#     def test_calculate_captital_investment_no_dr_idv(self):
-#         pass
+        results = {
+            "CapitalCost": capital_cost,
+            "NewCapacity": new_capacity,
+            "REGION": region,
+            "YEAR": year,
+            "DiscountRate": discount_rate,
+            "DiscountRateIdv": discount_rate_idv_empty,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.capital_investment()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.5990],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1.1230],
+                ["SIMPLICITY", "DUMMY", 2014, 5.520],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
 
 
 class TestCapitalRecoveryFactor:

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -672,7 +672,7 @@ class TestCapitalInvestment:
 
         assert_frame_equal(actual, expected)
 
-    def test_calculate_captital_investment_no_dr_idv(
+    def test_calculate_captital_investment_empty_dr_idv(
         self,
         capital_cost,
         new_capacity,
@@ -691,6 +691,38 @@ class TestCapitalInvestment:
             "YEAR": year,
             "DiscountRate": discount_rate,
             "DiscountRateIdv": discount_rate_idv_empty,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.capital_investment()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DUMMY", 2014, 4.104],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.599],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 5.52],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+    def test_calculate_captital_investment_no_dr_idv(
+        self,
+        capital_cost,
+        new_capacity,
+        operational_life,
+        region,
+        year,
+        discount_rate,
+    ):
+
+        results = {
+            "CapitalCost": capital_cost,
+            "NewCapacity": new_capacity,
+            "OperationalLife": operational_life,
+            "REGION": region,
+            "YEAR": year,
+            "DiscountRate": discount_rate,
         }
 
         package = ResultsPackage(results)

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -183,8 +183,10 @@ def capital_cost():
         data=[
             ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.23],
             ["SIMPLICITY", "GAS_EXTRACTION", 2015, 2.34],
-            ["SIMPLICITY", "DUMMY", 2015, 3.45],
-            ["SIMPLICITY", "DUMMY", 2016, 4.56],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 3.45],
+            ["SIMPLICITY", "DUMMY", 2014, 4.56],
+            ["SIMPLICITY", "DUMMY", 2015, 5.67],
+            ["SIMPLICITY", "DUMMY", 2016, 6.78],
         ],
         columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
     ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
@@ -637,12 +639,20 @@ class TestComputeTotalAnnualCapacity:
 
 class TestCapitalInvestment:
     def test_calculate_captital_investment_with_dr_idv(
-        self, discount_rate, discount_rate_idv
+        self,
+        capital_cost,
+        new_capacity,
+        operational_life,
+        region,
+        year,
+        discount_rate,
+        discount_rate_idv,
     ):
 
         results = {
             "CapitalCost": capital_cost,
             "NewCapacity": new_capacity,
+            "OperationalLife": operational_life,
             "REGION": region,
             "YEAR": year,
             "DiscountRate": discount_rate,
@@ -653,9 +663,9 @@ class TestCapitalInvestment:
         actual = package.capital_investment()
         expected = pd.DataFrame(
             data=[
+                ["SIMPLICITY", "DUMMY", 2014, 4.2898413],
                 ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.6352585],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 2.0126258],
-                ["SIMPLICITY", "DUMMY", 2014, 3.2456036],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 5.6451702],
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
@@ -663,12 +673,20 @@ class TestCapitalInvestment:
         assert_frame_equal(actual, expected)
 
     def test_calculate_captital_investment_no_dr_idv(
-        self, discount_rate, discount_rate_idv_empty
+        self,
+        capital_cost,
+        new_capacity,
+        operational_life,
+        region,
+        year,
+        discount_rate,
+        discount_rate_idv_empty,
     ):
 
         results = {
             "CapitalCost": capital_cost,
             "NewCapacity": new_capacity,
+            "OperationalLife": operational_life,
             "REGION": region,
             "YEAR": year,
             "DiscountRate": discount_rate,
@@ -679,9 +697,9 @@ class TestCapitalInvestment:
         actual = package.capital_investment()
         expected = pd.DataFrame(
             data=[
-                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.5990],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1.1230],
-                ["SIMPLICITY", "DUMMY", 2014, 5.520],
+                ["SIMPLICITY", "DUMMY", 2014, 4.104],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.599],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 5.52],
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
In this PR I have corrected how `DiscountRate` and `DiscountRateIdv` are used in the `CapitalInvestment` calculation. Specifically, the logic has been updated so: 
- If `DiscountRateIdv` is not found in input data, or is empty, the calculation will fall back to using `DiscountRate`. This addresses issue #220
- If `DiscountRateIdv` is found in input data, and has values, the calculation will pass `DiscountRateIdv` to the CRF calculation, and `DiscountRate` to the PVA calculation. This addresses #228

A test called `TestCapitalInvestment` has been added to test this logic. Also, the `DicountRateIdv` fixture was update so its values are different from the `DiscountRate` fixture. 

### Issue Ticket Number
<!--- Link corresponding issue number -->
Closes #220 
Closes #228

### Documentation
<!--- Where and how has this change been documented -->
na