### PR TITLE
Add discounted result calcualtions 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 1.1.4
+=============
+- Add result calculations for ``DiscountedCapitalInvestment``, ``DiscountedCostByTechnology``, and ``DiscountedOperationalCost``
+
 Version 1.1.3
 ===========================
 - Lock pandas to 2.1.4 or later

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-(Development) Version 1.1.3
+Version 1.1.3
 ===========================
 - Lock pandas to 2.1.4 or later
 - Capital Investment result calculation fixed

--- a/src/otoole/preprocess/config.yaml
+++ b/src/otoole/preprocess/config.yaml
@@ -342,6 +342,21 @@ Demand:
     type: result
     dtype: float
     default: 0
+DiscountedCapitalInvestment:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+DiscountedCostByTechnology:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
+DiscountedOperationalCost:
+    indices: [REGION, TECHNOLOGY, YEAR]
+    type: result
+    dtype: float
+    default: 0
 DiscountedSalvageValue:
     indices: [REGION, TECHNOLOGY, YEAR]
     type: result

--- a/src/otoole/results/result_package.py
+++ b/src/otoole/results/result_package.py
@@ -429,7 +429,7 @@ class ResultsPackage(Mapping):
             capital_investment = self["CapitalInvestment"]
 
         except KeyError as ex:
-            raise KeyError(self._msg("CapitalInvestment", str(ex)))
+            raise KeyError(self._msg("DiscountedCapitalInvestment", str(ex)))
 
         df = discount_factor(regions, years, discount_rate, 0.0)
 
@@ -491,7 +491,7 @@ class ResultsPackage(Mapping):
             annual_variable_operating_cost = self["AnnualVariableOperatingCost"]
 
         except KeyError as ex:
-            raise KeyError(self._msg("DiscountedOperatingCost", str(ex)))
+            raise KeyError(self._msg("DiscountedOperationalCost", str(ex)))
 
         df_mid = discount_factor(regions, years, discount_rate, 0.5)
 
@@ -549,7 +549,7 @@ class ResultsPackage(Mapping):
             discounted_salvage_value = self["DiscountedSalvageValue"]
 
         except KeyError as ex:
-            raise KeyError(self._msg("TotalDiscountedCostByTechnology", str(ex)))
+            raise KeyError(self._msg("DiscountedCostByTechnology", str(ex)))
 
         discounted_total_costs = discounted_operational_costs.add(
             discounted_capital_costs, fill_value=0.0

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -274,6 +274,65 @@ def annual_variable_operating_cost():
     return data
 
 
+@fixture
+def discounted_capital_costs():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 10],
+            ["SIMPLICITY", "DUMMY", 2015, 0],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 111],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 222],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 333],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
+@fixture
+def discounted_operational_costs():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 5],
+            ["SIMPLICITY", "DUMMY", 2015, 10],
+            ["SIMPLICITY", "DUMMY", 2016, 20],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 444],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 555],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 666],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
+@fixture
+def discounted_emissions_penalty():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 10],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 777],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
+@fixture
+def discounted_salvage_value():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 1],
+            ["SIMPLICITY", "DUMMY", 2015, 2],
+            ["SIMPLICITY", "DUMMY", 2016, 3],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 888],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 999],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
 @fixture(scope="function")
 def null() -> ResultsPackage:
     package = ResultsPackage({})
@@ -845,6 +904,39 @@ class TestDiscountedOperationalCost:
                 ["SIMPLICITY", "GAS_EXTRACTION", 2014, 433.29963238],
                 ["SIMPLICITY", "GAS_EXTRACTION", 2015, 1031.66579140],
                 ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1572.06215832],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestDiscountedCostByTechnology:
+    def test_calculate_discounted_operational_cost(
+        self,
+        discounted_capital_costs,
+        discounted_operational_costs,
+        discounted_emissions_penalty,
+        discounted_salvage_value,
+    ):
+
+        results = {
+            "DiscountedCapitalInvestment": discounted_capital_costs,
+            "DiscountedOperationalCost": discounted_operational_costs,
+            "DiscountedTechnologyEmissionsPenalty": discounted_emissions_penalty,
+            "DiscountedSalvageValue": discounted_salvage_value,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.discounted_technology_cost()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DUMMY", 2014, 24.0],
+                ["SIMPLICITY", "DUMMY", 2015, 8.0],
+                ["SIMPLICITY", "DUMMY", 2016, 17.0],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, -333.0],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2015, -222.0],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1775.0],
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -233,9 +233,41 @@ def undiscounted_capital_investment():
         data=[
             ["SIMPLICITY", "DUMMY", 2014, 10],
             ["SIMPLICITY", "DUMMY", 2015, 0],
-            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 10],
-            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 10],
-            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 10],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 123],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 456],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 789],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
+@fixture
+def annual_fixed_operating_cost():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 10],
+            ["SIMPLICITY", "DUMMY", 2015, 0],
+            ["SIMPLICITY", "DUMMY", 2016, 10],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 123],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 456],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 789],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
+@fixture
+def annual_variable_operating_cost():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 10],
+            ["SIMPLICITY", "DUMMY", 2015, 10],
+            ["SIMPLICITY", "DUMMY", 2016, 0],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 321],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 654],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 987],
         ],
         columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
     ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
@@ -775,9 +807,44 @@ class TestDiscountedCapitalInvestment:
         expected = pd.DataFrame(
             data=[
                 ["SIMPLICITY", "DUMMY", 2014, 10],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 10],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2015, 9.52380952],
-                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 9.07029478],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 123],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2015, 434.28571428],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 715.64625850],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestDiscountedOperationalCost:
+    def test_calculate_discounted_operational_cost(
+        self,
+        region,
+        year,
+        discount_rate,
+        annual_fixed_operating_cost,
+        annual_variable_operating_cost,
+    ):
+
+        results = {
+            "REGION": region,
+            "YEAR": year,
+            "DiscountRate": discount_rate,
+            "AnnualFixedOperatingCost": annual_fixed_operating_cost,
+            "AnnualVariableOperatingCost": annual_variable_operating_cost,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.discounted_operational_cost()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DUMMY", 2014, 19.51800146],
+                ["SIMPLICITY", "DUMMY", 2015, 9.29428640],
+                ["SIMPLICITY", "DUMMY", 2016, 8.85170134],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 433.29963238],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2015, 1031.66579140],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 1572.06215832],
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -333,6 +333,22 @@ def discounted_salvage_value():
     return data
 
 
+@fixture
+def discounted_technology_cost():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 111],
+            ["SIMPLICITY", "DUMMY", 2015, 222],
+            ["SIMPLICITY", "DUMMY", 2016, 333],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 444],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 555],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 666],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
 @fixture(scope="function")
 def null() -> ResultsPackage:
     package = ResultsPackage({})
@@ -912,7 +928,7 @@ class TestDiscountedOperationalCost:
 
 
 class TestDiscountedCostByTechnology:
-    def test_calculate_discounted_operational_cost(
+    def test_calculate_discounted_cost_by_technology(
         self,
         discounted_capital_costs,
         discounted_operational_costs,
@@ -940,6 +956,30 @@ class TestDiscountedCostByTechnology:
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestTotalDiscountedCost:
+    def test_calculate_total_discounted_cost(
+        self,
+        discounted_technology_cost,
+    ):
+
+        results = {
+            "DiscountedCostByTechnology": discounted_technology_cost,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.total_discounted_cost()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", 2014, 555],
+                ["SIMPLICITY", 2015, 777],
+                ["SIMPLICITY", 2016, 999],
+            ],
+            columns=["REGION", "YEAR", "VALUE"],
+        ).set_index(["REGION", "YEAR"])
 
         assert_frame_equal(actual, expected)
 

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -860,6 +860,13 @@ class TestCapitalInvestment:
 
         assert_frame_equal(actual, expected)
 
+    def test_null(self, null: ResultsPackage):
+        """ """
+        package = null
+        with raises(KeyError) as ex:
+            package.capital_investment()
+        assert "Cannot calculate CapitalInvestment due to missing data" in str(ex)
+
 
 class TestDiscountedCapitalInvestment:
     def test_calculate_discounted_captital_investment(
@@ -890,6 +897,16 @@ class TestDiscountedCapitalInvestment:
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
 
         assert_frame_equal(actual, expected)
+
+    def test_null(self, null: ResultsPackage):
+        """ """
+        package = null
+        with raises(KeyError) as ex:
+            package.discounted_capital_investment()
+        assert (
+            "Cannot calculate DiscountedCapitalInvestment due to missing data"
+            in str(ex)
+        )
 
 
 class TestDiscountedOperationalCost:
@@ -926,6 +943,15 @@ class TestDiscountedOperationalCost:
 
         assert_frame_equal(actual, expected)
 
+    def test_null(self, null: ResultsPackage):
+        """ """
+        package = null
+        with raises(KeyError) as ex:
+            package.discounted_operational_cost()
+        assert "Cannot calculate DiscountedOperationalCost due to missing data" in str(
+            ex
+        )
+
 
 class TestDiscountedCostByTechnology:
     def test_calculate_discounted_cost_by_technology(
@@ -959,6 +985,15 @@ class TestDiscountedCostByTechnology:
 
         assert_frame_equal(actual, expected)
 
+    def test_null(self, null: ResultsPackage):
+        """ """
+        package = null
+        with raises(KeyError) as ex:
+            package.discounted_technology_cost()
+        assert "Cannot calculate DiscountedCostByTechnology due to missing data" in str(
+            ex
+        )
+
 
 class TestTotalDiscountedCost:
     def test_calculate_total_discounted_cost(
@@ -982,6 +1017,13 @@ class TestTotalDiscountedCost:
         ).set_index(["REGION", "YEAR"])
 
         assert_frame_equal(actual, expected)
+
+    def test_null(self, null: ResultsPackage):
+        """ """
+        package = null
+        with raises(KeyError) as ex:
+            package.total_discounted_cost()
+        assert "Cannot calculate TotalDiscountedCost due to missing data" in str(ex)
 
 
 class TestCapitalRecoveryFactor:

--- a/tests/results/test_results_package.py
+++ b/tests/results/test_results_package.py
@@ -227,6 +227,21 @@ def variable_cost():
     return data
 
 
+@fixture
+def undiscounted_capital_investment():
+    data = pd.DataFrame(
+        data=[
+            ["SIMPLICITY", "DUMMY", 2014, 10],
+            ["SIMPLICITY", "DUMMY", 2015, 0],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2014, 10],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2015, 10],
+            ["SIMPLICITY", "GAS_EXTRACTION", 2016, 10],
+        ],
+        columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+    ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+    return data
+
+
 @fixture(scope="function")
 def null() -> ResultsPackage:
     package = ResultsPackage({})
@@ -732,6 +747,37 @@ class TestCapitalInvestment:
                 ["SIMPLICITY", "DUMMY", 2014, 4.104],
                 ["SIMPLICITY", "GAS_EXTRACTION", 2014, 1.599],
                 ["SIMPLICITY", "GAS_EXTRACTION", 2016, 5.52],
+            ],
+            columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        ).set_index(["REGION", "TECHNOLOGY", "YEAR"])
+
+        assert_frame_equal(actual, expected)
+
+
+class TestDiscountedCapitalInvestment:
+    def test_calculate_discounted_captital_investment(
+        self,
+        region,
+        year,
+        undiscounted_capital_investment,
+        discount_rate,
+    ):
+
+        results = {
+            "REGION": region,
+            "YEAR": year,
+            "DiscountRate": discount_rate,
+            "CapitalInvestment": undiscounted_capital_investment,
+        }
+
+        package = ResultsPackage(results)
+        actual = package.discounted_capital_investment()
+        expected = pd.DataFrame(
+            data=[
+                ["SIMPLICITY", "DUMMY", 2014, 10],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2014, 10],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2015, 9.52380952],
+                ["SIMPLICITY", "GAS_EXTRACTION", 2016, 9.07029478],
             ],
             columns=["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
         ).set_index(["REGION", "TECHNOLOGY", "YEAR"])


### PR DESCRIPTION
<!--- Provide a short description of the pull request -->

### Description
<!--- Describe your changes in detail -->
I have an application where I want to use the `DiscountedCostByTechnology` result variable. However, `otoole` does this calculation internally within the `TotalDiscountedCost` calculation, and does not print out this data. This PR addresses this. 

Specifically, in this PR I have: 

- Broken out the calculations for `DiscountedCapitalInvestment`, `DiscountedCostByTechnology`, and `DiscountedOperationalCost` into separate functions. When results are calculated, dataframes for each of these are generated, which can be written out in csvs or xlsx. 

- Functions that rely on this data (such as `TotalDiscountedCost`), now use these intermediate dataframes to perform the calculation. This simplifies the `TotalDiscountedCost` result calculation quite a bit. 

- Tests for each of `TotalDiscountedCost`, `DiscountedCapitalInvestment`, `DiscountedCostByTechnology`, and `DiscountedOperationalCost` have been added. 

- Updated the setup config file to write out `DiscountedCapitalInvestment`, `DiscountedCostByTechnology`, and `DiscountedOperationalCost` by default. 

Additionally, I have
- Checked that running Simplicity on this version and on version `1.1.3` produced identical results

**IMPORTANT NOTE ON THE TOTAL DISCOUNTED COST**
I believe otoole is currently following the old (incorrect) objective function definition found in `OSeMOSYS_fast` - it does not account for costs of storage (see [this issue ticket](https://github.com/OSeMOSYS/OSeMOSYS_GNU_MathProg/issues/83) for description). However, this has since been corrected with OSeMOSYS PR [81](https://github.com/OSeMOSYS/OSeMOSYS_GNU_MathProg/pull/89) and [91](https://github.com/OSeMOSYS/OSeMOSYS_GNU_MathProg/pull/91). This PR does **NOT** correct this issue, as it only updates implementation details and results stay the same. A new ticket (#237) has been created to address the incorrect calcualtion.  

### Issue Ticket Number
<!--- Link corresponding issue number -->
na

### Documentation
<!--- Where and how has this change been documented -->
na 